### PR TITLE
Feature/Frontend-access-restriction

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,6 +19,7 @@
         "@types/react-dom": "^18.3.0",
         "antd": "^5.21.1",
         "axios": "^1.7.7",
+        "moment": "^2.30.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-query": "^3.39.3",
@@ -26,6 +27,9 @@
         "react-scripts": "5.0.1",
         "typescript": "^4.9.5",
         "web-vitals": "^2.1.4"
+      },
+      "devDependencies": {
+        "@types/moment": "^2.13.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -4413,6 +4417,16 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w=="
+    },
+    "node_modules/@types/moment": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@types/moment/-/moment-2.13.0.tgz",
+      "integrity": "sha512-DyuyYGpV6r+4Z1bUznLi/Y7HpGn4iQ4IVcGn8zrr1P4KotKLdH0sbK1TFR6RGyX6B+G8u83wCzL+bpawKU/hdQ==",
+      "deprecated": "This is a stub types definition for Moment (https://github.com/moment/moment). Moment provides its own type definitions, so you don't need @types/moment installed!",
+      "dev": true,
+      "dependencies": {
+        "moment": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "16.18.108",
@@ -12865,6 +12879,14 @@
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/ms": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "@types/react-dom": "^18.3.0",
     "antd": "^5.21.1",
     "axios": "^1.7.7",
+    "moment": "^2.30.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-query": "^3.39.3",
@@ -45,5 +46,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "@types/moment": "^2.13.0"
   }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -46,6 +46,7 @@ const LockerSearch = lazy(() => import('./routes/admin/LockerSearch'));
 const LockerSelect = lazy(() => import('./routes/admin/LockerSelect'));
 const LockerReset = lazy(() => import('./routes/admin/LockerReset'));
 const AdminCircleSelect = lazy(() => import('./routes/admin/CircleSelect'));
+const CircleAccessLimit = lazy(() => import('./routes/admin/CircleAccessLimit'));
 
 function App() {
   return (
@@ -85,6 +86,7 @@ function App() {
             <Route path='/admin/circle' element={<PrivateRoute><AdminCircleSelect/></PrivateRoute>} />
             <Route path='/admin/locker/reset' element={<PrivateRoute><LockerReset /></PrivateRoute>} />
             <Route path='/admin/locker/search' element={<PrivateRoute><LockerSearch /></PrivateRoute>} />
+            <Route path='/admin/circle/access' element={<PrivateRoute><CircleAccessLimit /></PrivateRoute>} />
 
             <Route path='/locker/nopage' element={<Page404 />} />
             <Route path='/circle/nopage' element={<Page404 />} />

--- a/frontend/src/routes/admin/CircleAccessLimit.tsx
+++ b/frontend/src/routes/admin/CircleAccessLimit.tsx
@@ -1,0 +1,150 @@
+import React, { useState, useEffect } from 'react';
+import { Form, DatePicker, TimePicker, Button, message, Card, Row, Col } from 'antd';
+import axios from 'axios';
+import moment, { Moment } from 'moment';
+
+const AccessRestrictionPage: React.FC = () => {
+const [loading, setLoading] = useState(false);
+const [form] = Form.useForm();
+
+// ISO形式かどうかをチェックする正規表現
+const isoDateTimeRegex = /^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}Z$/;
+
+// レスポンスデータが有効かどうかをチェックする関数
+const isValidResponseData = (data: any): data is { start: string; end: string } => {
+    return (
+    typeof data === 'object' &&
+    typeof data.start === 'string' &&
+    typeof data.end === 'string' &&
+    moment(data.start).isValid() &&
+    moment(data.end).isValid() &&
+    isoDateTimeRegex.test(data.start) &&
+    isoDateTimeRegex.test(data.end)
+    );
+};
+
+// 現在設定されている時刻を取得する関数
+const fetchCurrentSettings = async () => {
+    try {
+    const response = await axios.get('/api/circle/access/setting');
+    if (response.status === 200 && response.data && isValidResponseData(response.data)) {
+        console.log(response.data);
+        const { start, end } = response.data;
+
+        // フォームに取得した値を設定
+        form.setFieldsValue({
+        date1: moment(start),
+        time1: moment(start),
+        date2: moment(end),
+        time2: moment(end),
+        });
+
+        message.success('現在の設定を取得しました。');
+    } else {
+        throw new Error('Unexpected response structure');
+    }
+    } catch (error) {
+    console.error('Failed to fetch current settings:', error);
+    message.error('現在の設定を取得できませんでした。');
+    }
+};
+
+useEffect(() => {
+    fetchCurrentSettings();
+}, []);
+
+// 時間が正しいかをチェックする関数
+const validateTimes = (start: string, end: string): boolean => {
+    const startTime = moment(start);
+    const endTime = moment(end);
+
+    // 開始時刻が終了時刻より前であることを確認
+    return startTime.isValid() && endTime.isValid() && startTime.isBefore(endTime);
+};
+
+// フォーム提出ハンドラー
+const onFinish = async (values: { date1: Moment; time1: Moment; date2: Moment; time2: Moment }) => {
+    setLoading(true);
+
+    // 日付と時刻を結合する
+    const startDateTime = moment(`${values.date1.format('YYYY-MM-DD')} ${values.time1.format('HH:mm')}`).toISOString();
+    const endDateTime = moment(`${values.date2.format('YYYY-MM-DD')} ${values.time2.format('HH:mm')}`).toISOString();
+
+    console.log(startDateTime, endDateTime);
+
+    // 無効な時間の場合はエラーメッセージを表示
+    if (!validateTimes(startDateTime, endDateTime)) {
+        message.error('無効な時間設定です。時間範囲を再度確認してください。');
+        setLoading(false);
+    return;
+    }
+
+    try {
+    const response = await axios.post('/api/circle/access/setting', {
+        start: startDateTime,
+        end: endDateTime,
+    });
+
+    if (response.status === 201) {
+        message.success('設定が完了しました！');
+    } else {
+        message.error('サーバーエラーが発生しました。もう一度実行してください。');
+    }
+    } catch (error) {
+        console.error(error);
+        message.error('内部エラーが生じました。管理者にお問い合わせください。');
+    } finally {
+        setLoading(false);
+    }
+};
+
+return (
+    <Row justify="center" style={{ marginTop: '50px' }}>
+    <Col xs={24} sm={20} md={16} lg={12} xl={10}>
+        <Card title="アクセス制限設定" bordered={true}>
+        <Form layout="vertical" form={form} onFinish={onFinish}>
+            <Form.Item
+            label="開始日"
+            name="date1"
+            rules={[{ required: true, message: '開始日を設定してください' }]}
+            >
+            <DatePicker style={{ width: '100%' }} />
+            </Form.Item>
+
+            <Form.Item
+            label="開始時刻"
+            name="time1"
+            rules={[{ required: true, message: '開始時刻を設定してください' }]}
+            >
+            <TimePicker style={{ width: '100%' }} format="HH:mm" />
+            </Form.Item>
+
+            <Form.Item
+            label="終了日"
+            name="date2"
+            rules={[{ required: true, message: '終了日を設定してください' }]}
+            >
+            <DatePicker style={{ width: '100%' }} />
+            </Form.Item>
+
+            <Form.Item
+            label="終了時刻"
+            name="time2"
+            rules={[{ required: true, message: '終了時刻を設定してください' }]}
+            >
+            <TimePicker style={{ width: '100%' }} format="HH:mm" />
+            </Form.Item>
+
+            <Form.Item>
+            <Button type="primary" htmlType="submit" loading={loading} block>
+                設定する
+            </Button>
+            </Form.Item>
+        </Form>
+        </Card>
+    </Col>
+    </Row>
+);
+};
+
+export default AccessRestrictionPage;

--- a/frontend/src/routes/admin/CircleSelect.tsx
+++ b/frontend/src/routes/admin/CircleSelect.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import SelectLayout from '../component/PageSelectLayout';
 
 const content = [
-    { title: 'アクセス制限', route: '/admin/circle/access-limit' },
-    { title: '団体情報照会', route: '/admin/circle/info' },
+    { title: 'アクセス制限', route: '/admin/circle/access' },
+    { title: '団体情報照会', route: '/admin/circle/list' },
 ];
 
 const LockerSelect: React.FC = () => {


### PR DESCRIPTION
This pull request includes several changes to add a new feature for setting access restrictions in the admin panel and updates dependencies. The most important changes include adding the `moment` library and its type definitions, updating routes and components to support the new access restriction feature, and implementing the `CircleAccessLimit` component.

### New Feature: Access Restriction

* [`frontend/src/App.tsx`](diffhunk://#diff-e56cb91573ddb6a97ecd071925fe26504bb5a65f921dc64c63e534162950e1ebR49): Added a new route for `/admin/circle/access` and imported the `CircleAccessLimit` component. [[1]](diffhunk://#diff-e56cb91573ddb6a97ecd071925fe26504bb5a65f921dc64c63e534162950e1ebR49) [[2]](diffhunk://#diff-e56cb91573ddb6a97ecd071925fe26504bb5a65f921dc64c63e534162950e1ebR89)
* [`frontend/src/routes/admin/CircleAccessLimit.tsx`](diffhunk://#diff-5ad32d50480b8741ae76794ec05d99d850cc4feefbabbc11c08337c687867a01R1-R150): Implemented the `CircleAccessLimit` component, which includes a form for setting access restrictions using `DatePicker` and `TimePicker` from `antd`, and handles form submission with validation and API calls using `axios` and `moment`.
* [`frontend/src/routes/admin/CircleSelect.tsx`](diffhunk://#diff-c66cb1845cd392f5d90c3e2eda1db0b4a422297d50c5df1e19338de202d53229L5-R6): Updated the route paths for access restriction and circle information.

### Dependency Updates

* [`frontend/package.json`](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655R17): Added `moment` and `@types/moment` to dependencies and devDependencies respectively. [[1]](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655R17) [[2]](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655R49-R51)
* [`frontend/package-lock.json`](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aR22-R32): Added `moment` and `@types/moment` with their respective versions and integrity hashes. [[1]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aR22-R32) [[2]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aR4421-R4430) [[3]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aR12884-R12891)