### PR TITLE
Feature/backend-circle-status

### DIFF
--- a/src/adapters/controller.rs
+++ b/src/adapters/controller.rs
@@ -27,6 +27,7 @@ use utoipa::OpenApi;
         register_token_generator,
         circle_main_auth,
         circle_co_auth,
+        circle_status,
     ),
     components(schemas(
         HealthCheckRequest,

--- a/src/adapters/httpmodels.rs
+++ b/src/adapters/httpmodels.rs
@@ -136,3 +136,26 @@ pub struct CircleUpdateRequest {
     pub student_id: String,
     pub email: String,
 }
+
+/// ### OrganizationStatus
+///
+/// OrganizationStatusResponseに使用する構造体
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct OrganizationStatus {
+    pub organization_id: String,
+    pub organization_name: String,
+    pub status_acceptance: String,
+    pub status_authentication: String,
+    pub status_form_comfirmation: String,
+    pub status_registration_complete: String,
+}
+
+/// ### OrganizationStatusResponse
+///
+/// 団体情報取得に使用
+#[derive(Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct OrganizationStatusResponse {
+    pub data: Vec<OrganizationStatus>,
+}

--- a/src/adapters/repository/registration.rs
+++ b/src/adapters/repository/registration.rs
@@ -32,6 +32,9 @@ pub trait RegistrationRepository: Send + Sync {
         co_student_id: &String,
     ) -> Result<Registration, Error>;
 
+    async fn get_all (
+        &self,
+    ) -> Result<Vec<Registration>, Error>;
 }
 
 pub struct RegistrationRepositorySqlImpl {
@@ -90,5 +93,12 @@ impl RegistrationRepository for RegistrationRepositorySqlImpl {
             .filter(registration::organization_id.eq(organization_id))
             .set((registration::main_student_id.eq(main_student_id), registration::co_student_id.eq(co_student_id), registration::updated_at.eq(diesel::dsl::now)))
             .get_result(&mut conn)
+    }
+
+    async fn get_all (
+            &self,
+        ) -> Result<Vec<Registration>, Error> {
+        let mut conn = self.pool.get().unwrap();
+        registration::table.get_results(&mut conn)
     }
 }

--- a/src/adapters/repository/registration.rs
+++ b/src/adapters/repository/registration.rs
@@ -1,7 +1,6 @@
 use diesel::pg::PgConnection;
 use diesel::prelude::*;
 use diesel::result::Error;
-use uuid::Uuid;
 use async_trait::async_trait;
 
 use crate::infrastructure::schema::*;

--- a/src/adapters/repository/representatives.rs
+++ b/src/adapters/repository/representatives.rs
@@ -1,7 +1,6 @@
 use diesel::pg::PgConnection;
 use diesel::prelude::*;
 use diesel::result::Error;
-use uuid::Uuid;
 use async_trait::async_trait;
 
 use crate::infrastructure::schema::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,6 +75,7 @@ async fn main() -> Result<(), rocket::Error> {
                 update_token_generator,
                 circle_main_auth,
                 circle_co_auth,
+                circle_status,
             ]
         )
         .mount("/", FileServer::from(relative!("frontend/build")))

--- a/src/usecase/organization.rs
+++ b/src/usecase/organization.rs
@@ -14,6 +14,8 @@ pub trait OrganizationUsecase: Sync + Send {
     async fn register(&self, organization: &Organization) -> Result<models::Organization, Error>;
 
     async fn update_email(&self, organization_id: &i32, organization_email: &String) -> Result<models::Organization, Error>;
+
+    async fn get_by_id(&self, organization_id: &i32) -> Result<models::Organization, Error>;
 }
 
 impl OrganizationUsecaseImpl {
@@ -32,5 +34,10 @@ impl OrganizationUsecase for OrganizationUsecaseImpl {
     async fn update_email(&self, organization_id: &i32, organization_email: &String) -> Result<models::Organization, Error> {
         // 団体メールアドレスの更新
         self.organization_repository.update_email_by_id(organization_id, organization_email).await
+    }
+
+    async fn get_by_id(&self, organization_id: &i32) -> Result<models::Organization, Error> {
+        // 団体情報の取得
+        self.organization_repository.get_by_id(organization_id).await
     }
 }

--- a/src/usecase/registration.rs
+++ b/src/usecase/registration.rs
@@ -16,6 +16,8 @@ pub trait RegistrationUsecase: Sync + Send {
     async fn register(&self, organization: &OrganizationInfo, organization_id: &i32) -> Result<Registration, Error>;
 
     async fn update_student(&self, organization_id: &i32, main_student_id: &String, co_student_id: &String) -> Result<Registration, Error>;
+
+    async fn get_all(&self) -> Result<Vec<Registration>, Error>;
 }
 
 impl RegistrationUsecaseImpl {
@@ -50,5 +52,10 @@ impl RegistrationUsecase for RegistrationUsecaseImpl {
     async fn update_student(&self, organization_id: &i32, main_student_id: &String, co_student_id: &String) -> Result<Registration, Error> {
         // 団体代表者と団体副代表者の更新
         self.registration_repository.update_student_by_id(organization_id, main_student_id, co_student_id).await
+    }
+
+    async fn get_all(&self) -> Result<Vec<Registration>, Error> {
+        // 団体情報を更新
+        self.registration_repository.get_all().await
     }
 }

--- a/src/usecase/registration.rs
+++ b/src/usecase/registration.rs
@@ -29,15 +29,18 @@ impl RegistrationUsecase for RegistrationUsecaseImpl {
     async fn register(&self, organization: &OrganizationInfo, organization_id: &i32) -> Result<Registration, Error> {
         // 団体情報の登録
         let year = Local::now().year();
-        let init_status = String::from("Pending");
+        let init_status_acpt = String::from("pending");
+        let init_status_auth = String::from("not_authenticated");
+        let init_status_form = String::from("not_confirmed");
+        let init_status_rgst = String::from("incomplete");
         self.registration_repository.insert(organization_id,
                                             &year,
                                             &organization.main_user.student_id,
                                             &organization.co_user.student_id,
-                                            &init_status,
-                                            &init_status,
-                                            &init_status,
-                                            &init_status,
+                                            &init_status_acpt,
+                                            &init_status_auth,
+                                            &init_status_form,
+                                            &init_status_rgst,
                                             &organization.b_doc,
                                             &organization.c_doc,
                                             &organization.d_doc


### PR DESCRIPTION
## 概要
- 団体情報取得APIを作成
  - データベースから登録されている全ての団体の団体ID、団体名、各種statusを取得します。
- registrationデータベースを修正
  - ステータス関連の初期値がドキュメントと異なっていたため修正

## テスト状態
swagger-ui上で実行

## 要望
コードレビュー、ローカルでの確認