### PR TITLE
Fix/Frontend-circle-status

### DIFF
--- a/frontend/src/routes/circle/Status.tsx
+++ b/frontend/src/routes/circle/Status.tsx
@@ -49,7 +49,7 @@ const CircleRegister: React.FC = () => {
 
         const fetchOrganizations = async () => {
             try {
-                const response = await axios.post<{ data: Organization[] }>('/api/circle/status');
+                const response = await axios.get<{ data: Organization[] }>('/api/circle/status');
                 setOrganizations(response.data.data);
                 setFilteredData(response.data.data);
             } catch (error) {

--- a/frontend/src/routes/circle/Status.tsx
+++ b/frontend/src/routes/circle/Status.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Table, Typography, Layout, Input, message } from 'antd';
-// import axios from 'axios';
+import axios from 'axios';
 import CustomHeader from '../component/CustomHeader';
 import CustomFooter from '../component/CustomFooter';
 
@@ -16,57 +16,6 @@ interface Organization {
     statusFormConfirmation: string;
     statusRegistrationComplete: string;
 }
-
-const mockData: Organization[] = [
-    {
-        organizationId: "550e8400-e29b-41d4-a716-446655440000",
-        organizationName: "団体A",
-        statusAcceptance: "accepted",
-        statusAuthentication: "authenticated",
-        statusFormConfirmation: "confirmed",
-        statusRegistrationComplete: "completed"
-    },
-    {
-        organizationId: "550e8400-e29b-41d4-a716-446655440001",
-        organizationName: "団体B",
-        statusAcceptance: "pending",
-        statusAuthentication: "not_authenticated",
-        statusFormConfirmation: "not_confirmed",
-        statusRegistrationComplete: "incomplete"
-    },
-    {
-        organizationId: "550e8400-e29b-41d4-a716-446655440002",
-        organizationName: "団体C",
-        statusAcceptance: "accepted",
-        statusAuthentication: "authenticated",
-        statusFormConfirmation: "confirmed",
-        statusRegistrationComplete: "completed"
-    },
-    {
-        organizationId: "550e8400-e29b-41d4-a716-446655440003",
-        organizationName: "団体D",
-        statusAcceptance: "pending",
-        statusAuthentication: "not_authenticated",
-        statusFormConfirmation: "not_confirmed",
-        statusRegistrationComplete: "incomplete"
-    },
-    {
-        organizationId: "550e8400-e29b-41d4-a716-446655440004",
-        organizationName: "団体E",
-        statusAcceptance: "accepted",
-        statusAuthentication: "authenticated",
-        statusFormConfirmation: "confirmed",
-        statusRegistrationComplete: "completed"
-    },
-    {
-        organizationId: "550e8400-e29b-41d4-a716-446655440005",
-        organizationName: "団体F",
-        statusAcceptance: "pending",
-        statusAuthentication: "not_authenticated",
-        statusFormConfirmation: "not_confirmed",
-        statusRegistrationComplete: "incomplete"
-    },
-];
 
 const pageSize = 5;
 
@@ -97,18 +46,10 @@ const CircleRegister: React.FC = () => {
     const [currentPage, setCurrentPage] = useState<number>(1);
 
     useEffect(() => {
-        // モックデータを使用
-        setTimeout(() => {
-            setOrganizations(mockData);
-            setFilteredData(mockData);
-            setLoading(false);
-        }, 1000);
 
-        // 本来は以下のようにAPIを叩いてデータを取得する
-        /*
         const fetchOrganizations = async () => {
             try {
-                const response = await axios.get<{ data: Organization[] }>('/api/circle/status');
+                const response = await axios.post<{ data: Organization[] }>('/api/circle/status');
                 setOrganizations(response.data.data);
                 setFilteredData(response.data.data);
             } catch (error) {
@@ -118,7 +59,6 @@ const CircleRegister: React.FC = () => {
             }
         };
         fetchOrganizations();
-        */
     }, []);
 
     const getStatusLabel = (status: string, statusType: string) => {

--- a/frontend/src/routes/circle/Status.tsx
+++ b/frontend/src/routes/circle/Status.tsx
@@ -50,6 +50,7 @@ const CircleRegister: React.FC = () => {
         const fetchOrganizations = async () => {
             try {
                 const response = await axios.get<{ data: Organization[] }>('/api/circle/status');
+                console.log(response.data.data);
                 setOrganizations(response.data.data);
                 setFilteredData(response.data.data);
             } catch (error) {

--- a/src/adapters/controller/circle.rs
+++ b/src/adapters/controller/circle.rs
@@ -378,7 +378,7 @@ pub async fn circle_status(app: &State<App>) -> Result<Json<OrganizationStatusRe
             organization_name: organization_info.organization_name,
             status_acceptance: element.status_acceptance,
             status_authentication: element.status_authentication,
-            status_form_comfirmation: element.status_form_comfirmation,
+            status_form_confirmation: element.status_form_confirmation,
             status_registration_complete: element.status_registration_complete,
         };
         response.push(data);

--- a/src/adapters/controller/circle.rs
+++ b/src/adapters/controller/circle.rs
@@ -365,7 +365,7 @@ pub async fn circle_co_auth(token: String, id: Option<String>, app:&State<App>) 
 
 // 団体情報取得API
 #[utoipa::path(context_path = "/api/circle")]
-#[post("/status")]
+#[get("/status")]
 pub async fn circle_status(app: &State<App>) -> Result<Json<OrganizationStatusResponse>, Status> {
 
     let result = app.registration.get_all().await.unwrap();

--- a/src/adapters/httpmodels.rs
+++ b/src/adapters/httpmodels.rs
@@ -147,7 +147,7 @@ pub struct OrganizationStatus {
     pub organization_name: String,
     pub status_acceptance: String,
     pub status_authentication: String,
-    pub status_form_comfirmation: String,
+    pub status_form_confirmation: String,
     pub status_registration_complete: String,
 }
 

--- a/src/infrastructure/models.rs
+++ b/src/infrastructure/models.rs
@@ -233,7 +233,7 @@ pub struct Registration{
     pub co_student_id: String,
     pub status_acceptance: String,
     pub status_authentication: String,
-    pub status_form_comfirmation: String,
+    pub status_form_confirmation: String,
     pub status_registration_complete: String,
     pub b_doc: String,
     pub c_doc: String,


### PR DESCRIPTION
This pull request includes changes to the `frontend/src/routes/circle/Status.tsx` file to switch from using mock data to fetching data from an API. The most important changes involve importing `axios`, removing the mock data, and updating the data fetching logic.

Data fetching improvements:

* [`frontend/src/routes/circle/Status.tsx`](diffhunk://#diff-e496cb2e22e2573e0a5a6ab4bde587ccaacf3b2ae47dd06e41c199c419144aabL3-R3): Imported `axios` to enable API requests.
* [`frontend/src/routes/circle/Status.tsx`](diffhunk://#diff-e496cb2e22e2573e0a5a6ab4bde587ccaacf3b2ae47dd06e41c199c419144aabL20-L70): Removed the `mockData` array and its related usage.
* [`frontend/src/routes/circle/Status.tsx`](diffhunk://#diff-e496cb2e22e2573e0a5a6ab4bde587ccaacf3b2ae47dd06e41c199c419144aabL100-R52): Updated the `useEffect` hook to fetch data from the API using `axios.post` instead of using mock data. [[1]](diffhunk://#diff-e496cb2e22e2573e0a5a6ab4bde587ccaacf3b2ae47dd06e41c199c419144aabL100-R52) [[2]](diffhunk://#diff-e496cb2e22e2573e0a5a6ab4bde587ccaacf3b2ae47dd06e41c199c419144aabL121)