### PR TITLE
テストの冪等性確保

### DIFF
--- a/tests/availability.rs
+++ b/tests/availability.rs
@@ -41,6 +41,8 @@ pub async fn normal() {
     // Assert
     assert_eq!(response.status(), Status::Ok);
     assert_eq!(response.into_json::<LockerStatusResponse>().await.unwrap(), expected_result);
+
+    setup_db(&app).await;
 }
 
 // 正常系=floorが指定されていない
@@ -75,4 +77,6 @@ pub async fn floor_is_not_requested() {
     // Assert
     assert_eq!(response.status(), Status::Ok);
     assert_eq!(response.into_json::<LockerStatusResponse>().await.unwrap(), expected_result);
+
+    setup_db(&app).await;
 }

--- a/tests/healthcheck.rs
+++ b/tests/healthcheck.rs
@@ -4,11 +4,11 @@ extern crate tus_yuurikai_system;
 
 mod utils;
 
+use tus_yuurikai_system::infrastructure::router::App;
 use utils::{router::rocket, setup::setup_db};
 use rocket::local::asynchronous::Client;
 use rocket::http::{Status, ContentType};
 use tus_yuurikai_system::adapters::{controller, httpmodels::HealthCheckRequest};
-use tus_yuurikai_system::infrastructure::router::App;
 
 #[rocket::async_test]
 async fn get_healthcheck_test() {

--- a/tests/lockerregister.rs
+++ b/tests/lockerregister.rs
@@ -14,6 +14,7 @@ use tus_yuurikai_system::infrastructure::router::App;
 
 // 正常系
 #[rocket::async_test]
+#[ignore]
 async fn normal() {
 
     // Arrange
@@ -78,10 +79,13 @@ async fn normal() {
     // Assert
     assert_eq!(response.status(), Status::Created);
     assert_eq!(response.into_string().await.unwrap(), "success create assignment");
+
+    setup_db(&app).await;
 }
 
 // 正常系＝学籍番号にA,Bを許す
 #[rocket::async_test]
+#[ignore]
 async fn student_id_allow_a_b() {
 
     // Arrange
@@ -146,10 +150,13 @@ async fn student_id_allow_a_b() {
     // Assert
     assert_eq!(response.status(), Status::Created);
     assert_eq!(response.into_string().await.unwrap(), "success create assignment");
+
+    setup_db(&app).await;
 }
 
 // 異常系＝student_idがテーブル内のタプルと一致しない
 #[rocket::async_test]
+#[ignore]
 async fn student_id_do_not_match() {
 
     // Arrange
@@ -213,11 +220,14 @@ async fn student_id_do_not_match() {
     // Assert
     assert_eq!(response.status(), Status::InternalServerError);
     assert_eq!(response.into_string().await.unwrap(), "failed to get student_pair id");
+
+    setup_db(&app).await;
 }
 
 
 // 異常系＝yearが一致するタプルが存在しない
 #[rocket::async_test]
+#[ignore]
 async fn year_do_not_match() {
 
     // Arrange
@@ -278,10 +288,13 @@ async fn year_do_not_match() {
     // Assert
     assert_eq!(response.status(), Status::InternalServerError);
     assert_eq!(response.into_string().await.unwrap(), "failed to get student_pair id");
+
+    setup_db(&app).await;
 }
 
 // 異常系＝ロッカーのstatusがvacantでない
 #[rocket::async_test]
+#[ignore]
 async fn locker_status_unavailable() {
 
     // Arrange
@@ -352,10 +365,13 @@ async fn locker_status_unavailable() {
     // Assert
     assert_eq!(response.status(), Status::BadRequest);
     assert_eq!(response.into_string().await.unwrap(), "This locker is not vacant");
+
+    setup_db(&app).await;
 }
 
 // 異常系:既に登録されたペアである
 #[rocket::async_test]
+#[ignore]
 async fn same_pair_arleady_registered() {
 
     // Arrange
@@ -425,4 +441,6 @@ async fn same_pair_arleady_registered() {
     // Assert
     assert_eq!(response.status(), Status::InternalServerError);
     assert_eq!(response.into_string().await.unwrap(), "same pair already exists");
+
+    setup_db(&app).await;
 }

--- a/tests/lockerreset.rs
+++ b/tests/lockerreset.rs
@@ -80,6 +80,8 @@ async fn normal() {
 
     assert_eq!(response.status(), Status::Ok);
     assert_eq!(response.into_string().await.unwrap(), "successfully reset locker");
+
+    setup_db(&app).await;
 }
 
 // 正常系:モンキーテスト
@@ -146,6 +148,8 @@ async fn out_of_work_locker_exists() {
 
     assert_eq!(response.status(), Status::Ok);
     assert_eq!(response.into_string().await.unwrap(), "successfully reset locker");
+
+    setup_db(&app).await;
 }
 
 // 異常系:パスワードが無効
@@ -188,6 +192,8 @@ async fn request_password_is_not_valid() {
     // Assert
     assert_eq!(response.status(), Status::Unauthorized);
     assert_eq!(response.into_string().await.unwrap(), "request password does not match");
+
+    setup_db(&app).await;
 }
 
 // 異常系:jwtが存在しない
@@ -215,6 +221,8 @@ async fn jwt_is_not_exists() {
     // Assert
     assert_eq!(response.status(), Status::Unauthorized);
     assert_eq!(response.into_string().await.unwrap(), "request is unauthorized");
+
+    setup_db(&app).await;
 }
 
 // 異常系:jwtが無効
@@ -257,4 +265,6 @@ async fn jwt_is_not_valid() {
     // Assert
     assert_eq!(response.status(), Status::Unauthorized);
     assert_eq!(response.into_string().await.unwrap(), "request token is not valid");
+
+    setup_db(&app).await;
 }

--- a/tests/login.rs
+++ b/tests/login.rs
@@ -49,6 +49,7 @@ pub async fn normal() {
     assert_eq!(response.status(), Status::Created);
     assert_ne!(response.cookies().get("token"), None);
 
+    setup_db(&app).await;
 }
 
 // 異常系=存在しないusernameである
@@ -89,6 +90,8 @@ pub async fn username_does_not_exist() {
     // Assert
     assert_eq!(response.status(), Status::InternalServerError);
     assert_eq!(response.cookies().get("token"), None);
+
+    setup_db(&app).await;
 }
 
 // 異常系=passwordが異なる
@@ -131,4 +134,5 @@ pub async fn password_is_wrong() {
     assert_eq!(response.status(), Status::BadRequest);
     assert_eq!(response.cookies().get("token"), None);
 
+    setup_db(&app).await;
 }

--- a/tests/usersearch.rs
+++ b/tests/usersearch.rs
@@ -110,6 +110,8 @@ async fn normal() {
     // Assert
     assert_eq!(response.status(), Status::Ok);
     assert_eq!(response.into_json::<UserSearchResponse>().await.unwrap(), expected_data);
+
+    setup_db(&app).await;
 }
 
 // 正常系:given_nameが指定されていない
@@ -208,6 +210,8 @@ async fn given_name_is_not_requested() {
     // Assert
     assert_eq!(response.status(), Status::Ok);
     assert_eq!(response.into_json::<UserSearchResponse>().await.unwrap(), expected_data);
+
+    setup_db(&app).await;
 }
 
 // 正常系:family_nameが指定されていない
@@ -305,6 +309,8 @@ async fn family_name_is_not_requested() {
     // Assert
     assert_eq!(response.status(), Status::Ok);
     assert_eq!(response.into_json::<UserSearchResponse>().await.unwrap(), expected_data);
+
+    setup_db(&app).await;
 }
 
 // 正常系:nameが指定されていない
@@ -402,6 +408,8 @@ async fn name_is_not_requested() {
     // Assert
     assert_eq!(response.status(), Status::Ok);
     assert_eq!(response.into_json::<UserSearchResponse>().await.unwrap(), expected_data);
+
+    setup_db(&app).await;
 }
 
 // 異常系:jwtを所持していない
@@ -464,4 +472,6 @@ async fn jwt_does_not_exist() {
 
     // Assert
     assert_eq!(response.status(), Status::BadRequest);
+
+    setup_db(&app).await;
 }


### PR DESCRIPTION
## 概要
- 各結合テスト終了時にテストで使用したデータを消去する処理を追記しました。
- lockerregisterテストが無視されるようにしました。

## テスト状態
- `cargo test -- --test-threads=1`が正常に終了することを確認

## 要望
ローカルテスト、コードレビュー
  - テスト時、lockerregisterテストの各項目が無視されていること、テスト終了後メール送信が行われていないことも確認してください。