### PR TITLE
コマンドライン引数の導入

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,8 +1,17 @@
 #!/bin/bash
 
-cd frontend || exit
-npm run build
+if [ "$1" = 'local' ]; then
+    cd frontend || exit
+    npm run build
 
-cd ..
+    cd ..
 
-cargo run
+    cargo run same-student
+else
+    cd frontend || exit
+    npm run build
+
+    cd ..
+
+    cargo run
+fi

--- a/src/adapters/controller/locker.rs
+++ b/src/adapters/controller/locker.rs
@@ -35,6 +35,9 @@ pub async fn token_generator(request: Json<LockerTokenGenRequest>, app: &State<A
     if !(re.is_match(data.co_user.student_id.clone().as_str())) {
         return Status::BadRequest;
     }
+    if !app.option.same_student_enable && data.main_user.student_id.clone() == data.co_user.student_id.clone() {
+        return Status::BadRequest;
+    }
 
     // 氏名についてのバリデーション
     let re = Regex::new(r"^[A-Za-z\p{Kana}\p{Hira}\p{Han}]+$").unwrap();

--- a/src/infrastructure/router.rs
+++ b/src/infrastructure/router.rs
@@ -30,7 +30,21 @@ use crate::usecase::{
                 };
 
 pub type Pool<T> = diesel::r2d2::Pool<ConnectionManager<T>>;
+
+pub struct AppOption{
+    pub same_student_enable: bool,
+}
+
+impl AppOption {
+    pub fn new() -> Self {
+        AppOption {
+            same_student_enable: false,
+        }
+    }
+}
+
 pub struct App{
+    pub option: AppOption,
     pub student: StudentUsecaseImpl,
     pub student_pair: StudentPairUsecaseImpl,
     pub auth: AuthUsecaseImpl,
@@ -44,8 +58,10 @@ pub struct App{
 }
 
 impl App{
-    pub fn new() -> Self {
+    pub fn new(app_option: AppOption) -> Self {
         dotenv().ok();
+
+        let option = app_option;
 
         let database_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set.");
         let manager = ConnectionManager::<PgConnection>::new(&database_url);
@@ -63,6 +79,7 @@ impl App{
         let time_repository = TimeUsecaseImpl::new(Arc::new(TimeRepositorySqlImpl::new(pool.clone())));
 
         App {
+            option: option,
             student: student_repository,
             student_pair: student_pair_repository,
             auth: auth_repository,
@@ -79,6 +96,7 @@ impl App{
 
 impl Default for App {
     fn default() -> Self {
-        Self::new()
+        let option = AppOption::new();
+        Self::new(option)
     }
 }

--- a/tests/availability.rs
+++ b/tests/availability.rs
@@ -7,14 +7,15 @@ use utils::{router::rocket, setup::setup_db};
 use rocket::local::asynchronous::Client;
 use rocket::http::Status;
 use tus_yuurikai_system::adapters::httpmodels::{LockerStatus, LockerStatusResponse};
-use tus_yuurikai_system::infrastructure::router::App;
+use tus_yuurikai_system::infrastructure::router::{App, AppOption};
 
 // 正常系
 #[rocket::async_test]
 pub async fn normal() {
     // Arrange
     let client = Client::tracked(rocket()).await.unwrap();
-    let app = App::new();
+    let app_option = AppOption::new();
+    let app = App::new(app_option);
 
     setup_db(&app).await;
 
@@ -50,7 +51,8 @@ pub async fn normal() {
 pub async fn floor_is_not_requested() {
     // Arrange
     let client = Client::tracked(rocket()).await.unwrap();
-    let app = App::new();
+    let app_option = AppOption::new();
+    let app = App::new(app_option);
 
     setup_db(&app).await;
 

--- a/tests/healthcheck.rs
+++ b/tests/healthcheck.rs
@@ -4,7 +4,7 @@ extern crate tus_yuurikai_system;
 
 mod utils;
 
-use tus_yuurikai_system::infrastructure::router::App;
+use tus_yuurikai_system::infrastructure::router::{App, AppOption};
 use utils::{router::rocket, setup::setup_db};
 use rocket::local::asynchronous::Client;
 use rocket::http::{Status, ContentType};
@@ -31,7 +31,8 @@ async fn post_healthcheck_test() {
         text: String::from("Hello world from json!")
     };
 
-    let app = App::new();
+    let app_option = AppOption::new();
+    let app = App::new(app_option);
 
     setup_db(&app).await;
 

--- a/tests/lockerregister.rs
+++ b/tests/lockerregister.rs
@@ -10,7 +10,7 @@ use rocket::http::{Status, ContentType};
 use tus_yuurikai_system::adapters::{controller::locker, httpmodels::LockerResisterRequest};
 use tus_yuurikai_system::domain::{assignment::AssignmentInfo, student_pair::PairInfo, student::UserInfo};
 use tus_yuurikai_system::usecase::{student_pair::StudentPairUsecase, student::StudentUsecase, auth::AuthUsecase};
-use tus_yuurikai_system::infrastructure::router::App;
+use tus_yuurikai_system::infrastructure::router::{App, AppOption};
 
 // 正常系
 #[rocket::async_test]
@@ -19,7 +19,8 @@ async fn normal() {
 
     // Arrange
     let client = Client::tracked(rocket()).await.unwrap();
-    let app = App::new();
+    let app_option = AppOption::new();
+    let app = App::new(app_option);
 
     let mainuser = &UserInfo{
             student_id: String::from("4622999"),
@@ -90,7 +91,8 @@ async fn student_id_allow_a_b() {
 
     // Arrange
     let client = Client::tracked(rocket()).await.unwrap();
-    let app = App::new();
+    let app_option = AppOption::new();
+    let app = App::new(app_option);
 
     let mainuser = &UserInfo{
             student_id: String::from("3A22999"),
@@ -161,7 +163,8 @@ async fn student_id_do_not_match() {
 
     // Arrange
     let client = Client::tracked(rocket()).await.unwrap();
-    let app = App::new();
+    let app_option = AppOption::new();
+    let app = App::new(app_option);
 
     let mainuser = &UserInfo{
             student_id: String::from("4622999"),
@@ -232,7 +235,8 @@ async fn year_do_not_match() {
 
     // Arrange
     let client = Client::tracked(rocket()).await.unwrap();
-    let app = App::new();
+    let app_option = AppOption::new();
+    let app = App::new(app_option);
 
     let mainuser = &UserInfo{
             student_id: String::from("4622999"),
@@ -299,7 +303,8 @@ async fn locker_status_unavailable() {
 
     // Arrange
     let client = Client::tracked(rocket()).await.unwrap();
-    let app = App::new();
+    let app_option = AppOption::new();
+    let app = App::new(app_option);
 
     let mainuser = &UserInfo{
             student_id: String::from("4622999"),
@@ -376,7 +381,8 @@ async fn same_pair_arleady_registered() {
 
     // Arrange
     let client = Client::tracked(rocket()).await.unwrap();
-    let app = App::new();
+    let app_option = AppOption::new();
+    let app = App::new(app_option);
 
     let mainuser = &UserInfo{
             student_id: String::from("4622999"),

--- a/tests/lockerreset.rs
+++ b/tests/lockerreset.rs
@@ -11,7 +11,7 @@ use rocket::http::{Status, ContentType, Cookie};
 use dotenv::dotenv;
 use tus_yuurikai_system::adapters::{controller::locker, httpmodels::LockerResetRequest};
 use tus_yuurikai_system::utils::jwt::encode_jwt;
-use tus_yuurikai_system::infrastructure::router::App;
+use tus_yuurikai_system::infrastructure::router::{App, AppOption};
 use chrono::Duration;
 
 
@@ -22,7 +22,8 @@ async fn normal() {
 
     // Arrange
     let client = Client::tracked(rocket()).await.unwrap();
-    let app = App::new();
+    let app_option = AppOption::new();
+    let app = App::new(app_option);
 
     // dbの初期化
     setup_db(&app).await;
@@ -91,7 +92,8 @@ async fn out_of_work_locker_exists() {
 
     // Arrange
     let client = Client::tracked(rocket()).await.unwrap();
-    let app = App::new();
+    let app_option = AppOption::new();
+    let app = App::new(app_option);
 
     // dbの初期化
     setup_db(&app).await;
@@ -159,7 +161,8 @@ async fn request_password_is_not_valid() {
 
     // Arrange
     let client = Client::tracked(rocket()).await.unwrap();
-    let app = App::new();
+    let app_option = AppOption::new();
+    let app = App::new(app_option);
 
     // dbの初期化
     setup_db(&app).await;
@@ -203,7 +206,8 @@ async fn jwt_is_not_exists() {
 
     // Arrange
     let client = Client::tracked(rocket()).await.unwrap();
-    let app = App::new();
+    let app_option = AppOption::new();
+    let app = App::new(app_option);
 
     // dbの初期化
     setup_db(&app).await;
@@ -232,7 +236,8 @@ async fn jwt_is_not_valid() {
 
     // Arrange
     let client = Client::tracked(rocket()).await.unwrap();
-    let app = App::new();
+    let app_option = AppOption::new();
+    let app = App::new(app_option);
 
     // dbの初期化
     setup_db(&app).await;

--- a/tests/login.rs
+++ b/tests/login.rs
@@ -10,14 +10,15 @@ use rocket::local::asynchronous::Client;
 use rocket::http::{Status, ContentType};
 use dotenv::dotenv;
 use tus_yuurikai_system::adapters::{controller::locker, httpmodels::LoginFormRequest};
-use tus_yuurikai_system::infrastructure::router::App;
+use tus_yuurikai_system::infrastructure::router::{App, AppOption};
 
 // 正常系
 #[rocket::async_test]
 pub async fn normal() {
     // Arrange
     let client = Client::tracked(rocket()).await.unwrap();
-    let app = App::new();
+    let app_option = AppOption::new();
+    let app = App::new(app_option);
 
     dotenv().ok();
 
@@ -57,7 +58,8 @@ pub async fn normal() {
 pub async fn username_does_not_exist() {
     // Arrange
     let client = Client::tracked(rocket()).await.unwrap();
-    let app = App::new();
+    let app_option = AppOption::new();
+    let app = App::new(app_option);
 
     dotenv().ok();
 
@@ -99,7 +101,8 @@ pub async fn username_does_not_exist() {
 pub async fn password_is_wrong() {
     // Arrange
     let client = Client::tracked(rocket()).await.unwrap();
-    let app = App::new();
+    let app_option = AppOption::new();
+    let app = App::new(app_option);
 
     dotenv().ok();
 

--- a/tests/usersearch.rs
+++ b/tests/usersearch.rs
@@ -11,7 +11,7 @@ use dotenv::dotenv;
 use tus_yuurikai_system::adapters::httpmodels::{UserSearchResponse, UserSearchResult};
 use tus_yuurikai_system::domain::{assignment::AssignmentInfo, student_pair::PairInfo, student::UserInfo};
 use tus_yuurikai_system::usecase::{assignment_record::AssignmentRecordUsecase, student_pair::StudentPairUsecase, student::StudentUsecase};
-use tus_yuurikai_system::infrastructure::router::App;
+use tus_yuurikai_system::infrastructure::router::{App, AppOption};
 use tus_yuurikai_system::utils::jwt::encode_jwt;
 use chrono::{Datelike, Local, Duration};
 
@@ -20,7 +20,8 @@ use chrono::{Datelike, Local, Duration};
 async fn normal() {
     //Arrange
     let client = Client::tracked(rocket()).await.unwrap();
-    let app = App::new();
+    let app_option = AppOption::new();
+    let app = App::new(app_option);
 
     let mainuser = &UserInfo{
             student_id: String::from("4622999"),
@@ -119,7 +120,8 @@ async fn normal() {
 async fn given_name_is_not_requested() {
     //Arrange
     let client = Client::tracked(rocket()).await.unwrap();
-    let app = App::new();
+    let app_option = AppOption::new();
+    let app = App::new(app_option);
 
     let mainuser = &UserInfo{
             student_id: String::from("4622999"),
@@ -219,7 +221,8 @@ async fn given_name_is_not_requested() {
 async fn family_name_is_not_requested() {
     //Arrange
     let client = Client::tracked(rocket()).await.unwrap();
-    let app = App::new();
+    let app_option = AppOption::new();
+    let app = App::new(app_option);
 
     let mainuser = &UserInfo{
             student_id: String::from("4622999"),
@@ -318,7 +321,8 @@ async fn family_name_is_not_requested() {
 async fn name_is_not_requested() {
     //Arrange
     let client = Client::tracked(rocket()).await.unwrap();
-    let app = App::new();
+    let app_option = AppOption::new();
+    let app = App::new(app_option);
 
     let mainuser = &UserInfo{
             student_id: String::from("4622999"),
@@ -417,7 +421,8 @@ async fn name_is_not_requested() {
 async fn jwt_does_not_exist() {
     //Arrange
     let client = Client::tracked(rocket()).await.unwrap();
-    let app = App::new();
+    let app_option = AppOption::new();
+    let app = App::new(app_option);
 
     let mainuser = &UserInfo{
             student_id: String::from("4622999"),

--- a/tests/utils/router.rs
+++ b/tests/utils/router.rs
@@ -1,6 +1,6 @@
 extern crate tus_yuurikai_system;
 
-use tus_yuurikai_system::{infrastructure::router::App, adapters::controller::ApiDoc};
+use tus_yuurikai_system::{infrastructure::router::{App, AppOption}, adapters::controller::ApiDoc};
 use tus_yuurikai_system::adapters::controller::{*, locker::*};
 
 use rocket::{routes, Rocket, Build};
@@ -8,7 +8,8 @@ use utoipa_swagger_ui::SwaggerUi;
 use utoipa::OpenApi;
 
 pub fn rocket() -> Rocket<Build> {
-    let app = App::new();
+    let app_option = AppOption::new();
+    let app = App::new(app_option);
     let rocket = rocket::build()
         .manage(app)
         .mount(


### PR DESCRIPTION
## 概要
- コマンドライン引数を導入しました
- ロッカー登録において、学生のペアが同一の学籍番号を許すかどうかの設定を追加しました。
  - `same-student`をコマンドライン引数として指定することで、同一の学籍番号を許します。

## テスト状態
- swagger-ui、ui上で目視で確認

## 要望
- ローカルテストおよびコードレビュー