### PR TITLE
データベースに関する同期処理のオフロード

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2817,6 +2817,7 @@ dependencies = [
  "rocket_cors",
  "serde",
  "serde_json",
+ "thiserror 1.0.63",
  "utoipa",
  "utoipa-swagger-ui",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,4 @@ regex = "1.11.1"
 argon2 = { version = "0.5.3", features = ["password-hash"] }
 csv = "1.3.1"
 zip = "2.4.1"
+thiserror = "1.0"

--- a/src/adapters/controller/locker.rs
+++ b/src/adapters/controller/locker.rs
@@ -368,8 +368,8 @@ pub async fn locker_register(request: Json<LockerResisterRequest>, app: &State<A
 
     // 既に登録されていないかの確認
     match app.assignment_record.get_by_pair_id(&user_pair.pair_id).await {
-        Ok(_) => {return (Status::InternalServerError, "same pair already exists")},
-        Err(diesel::NotFound) => {},
+        Ok(Some(_)) => {return (Status::InternalServerError, "same pair already exists")},
+        Ok(None) => {},
         Err(_) => {return (Status::InternalServerError, "failed to get assignment_record")},
     }
 

--- a/src/adapters/repository.rs
+++ b/src/adapters/repository.rs
@@ -10,3 +10,15 @@ pub mod registration;
 pub mod representatives;
 pub mod organization;
 pub mod time;
+
+use diesel::result::Error as DieselError;
+use diesel::r2d2::PoolError as PoolError;
+
+#[derive(Debug, thiserror::Error)]
+pub enum RepositoryError {
+    #[error("DBConnectionError: {0}")]
+    ConnectionError(#[from] PoolError),
+
+    #[error("QueryError: {0}")]
+    DieselError(#[from] DieselError),
+}

--- a/src/adapters/repository/admin.rs
+++ b/src/adapters/repository/admin.rs
@@ -10,15 +10,15 @@ use crate::infrastructure::router::Pool;
 /// # admin
 #[async_trait]
 pub trait AdminRepository: Send + Sync {
-    async fn insert(
+    fn insert(
         &self,
         username: &String,
         password: &String
     ) -> Result<Admin, Error>;
 
-    async fn get_by_name(
+    fn get_by_name(
         &self,
-        username: &String,
+        username: String,
     ) -> Result<Admin, Error>;
 
     async fn delete_by_name(
@@ -43,7 +43,7 @@ impl AdminRepositorySqlImpl {
 
 #[async_trait]
 impl AdminRepository for AdminRepositorySqlImpl {
-    async fn insert (
+    fn insert (
         &self,
         username: &String,
         password: &String,
@@ -58,9 +58,9 @@ impl AdminRepository for AdminRepositorySqlImpl {
             .get_result(&mut conn)
     }
 
-    async fn get_by_name (
+    fn get_by_name (
             &self,
-            username: &String,
+            username: String,
     ) -> Result<Admin, Error> {
         let mut conn = self.pool.get().unwrap();
         admin::table.filter(admin::username.eq(username))

--- a/src/adapters/repository/admin.rs
+++ b/src/adapters/repository/admin.rs
@@ -1,34 +1,32 @@
 use diesel::pg::PgConnection;
 use diesel::prelude::*;
-use diesel::result::Error;
-use async_trait::async_trait;
 
 use crate::infrastructure::schema::*;
 use crate::infrastructure::models::*;
 use crate::infrastructure::router::Pool;
+use super::RepositoryError;
 
 /// # admin
-#[async_trait]
 pub trait AdminRepository: Send + Sync {
     fn insert(
         &self,
-        username: &String,
-        password: &String
-    ) -> Result<Admin, Error>;
+        username: String,
+        password: String
+    ) -> Result<Admin, RepositoryError>;
 
     fn get_by_name(
         &self,
         username: String,
-    ) -> Result<Admin, Error>;
+    ) -> Result<Admin, RepositoryError>;
 
-    async fn delete_by_name(
+    fn delete_by_name(
         &self,
-        username: &String,
-    ) -> Result<usize, Error>;
+        username: String,
+    ) -> Result<usize, RepositoryError>;
 
-    async fn delete_all(
+    fn delete_all(
         &self
-    ) -> Result<usize, Error>;
+    ) -> Result<usize, RepositoryError>;
 }
 
 pub struct AdminRepositorySqlImpl {
@@ -41,46 +39,53 @@ impl AdminRepositorySqlImpl {
     }
 }
 
-#[async_trait]
 impl AdminRepository for AdminRepositorySqlImpl {
     fn insert (
         &self,
-        username: &String,
-        password: &String,
-    ) -> Result<Admin, Error> {
+        username: String,
+        password: String,
+    ) -> Result<Admin, RepositoryError> {
         let new_admin = NewAdmin {
-            username,
-            password,
+            username: &username,
+            password: &password,
         };
-        let mut conn = self.pool.get().unwrap();
-        diesel::insert_into(admin::table)
+        let mut conn = self.pool.get()?;
+        let result = diesel::insert_into(admin::table)
             .values(&new_admin)
-            .get_result(&mut conn)
+            .get_result::<Admin>(&mut conn)?;
+
+        Ok(result)
     }
 
     fn get_by_name (
             &self,
             username: String,
-    ) -> Result<Admin, Error> {
-        let mut conn = self.pool.get().unwrap();
-        admin::table.filter(admin::username.eq(username))
-            .first(&mut conn)
+    ) -> Result<Admin, RepositoryError> {
+        let mut conn = self.pool.get()?;
+        let result = admin::table.filter(admin::username.eq(username))
+            .first::<Admin>(&mut conn)?;
+
+        Ok(result)
     }
 
-    async fn delete_by_name(
+    fn delete_by_name(
             &self,
-            username: &String,
-        ) -> Result<usize, Error> {
-        let mut conn = self.pool.get().unwrap();
-        diesel::delete(admin::table.find(username))
-            .execute(&mut conn)
+            username: String,
+        ) -> Result<usize, RepositoryError> {
+        let mut conn = self.pool.get()?;
+        let result = diesel::delete(admin::table.find(username))
+            .execute(&mut conn)?;
+
+        Ok(result)
     }
 
-    async fn delete_all(
+    fn delete_all(
         &self
-    ) -> Result<usize, Error> {
-        let mut conn = self.pool.get().unwrap();
-        diesel::delete(admin::table)
-            .execute(&mut conn)
+    ) -> Result<usize, RepositoryError> {
+        let mut conn = self.pool.get()?;
+        let result = diesel::delete(admin::table)
+            .execute(&mut conn)?;
+
+        Ok(result)
     }
 }

--- a/src/adapters/repository/assignment_record.rs
+++ b/src/adapters/repository/assignment_record.rs
@@ -2,40 +2,38 @@ use diesel::pg::PgConnection;
 use diesel::prelude::*;
 use diesel::result::Error;
 use uuid::Uuid;
-use async_trait::async_trait;
 
 use crate::infrastructure::schema::*;
 use crate::infrastructure::models::*;
 use crate::infrastructure::router::Pool;
 
 /// # assignment_record
-#[async_trait]
 pub trait AssignmentRecordRepository: Send + Sync {
-    async fn insert(
+    fn insert(
         &self,
-        pair_id: &Uuid,
-        locker_id: &String,
-        year: &i32,
+        pair_id: Uuid,
+        locker_id: String,
+        year: i32,
     ) -> Result<AssignmentRecord, Error>;
 
-    async fn get_all(
+    fn get_all(
         &self,
     ) -> Result<Vec<AssignmentRecord>, Error>;
 
-    async fn get(
+    fn get(
         &self,
-        year: &i32,
-        floor: &String,
-        pair_id: &Uuid,
+        year: i32,
+        floor: String,
+        pair_id: Uuid,
     ) -> Result<Vec<AssignmentRecord>, Error>;
 
-    async fn get_by_pair_id(
+    fn get_by_pair_id(
         &self,
-        year: &i32,
-        pair_id: &Uuid,
+        year: i32,
+        pair_id: Uuid,
     ) -> Result<AssignmentRecord, Error>;
 
-    async fn delete_all(
+    fn delete_all(
         &self
     ) -> Result<usize, Error>;
 }
@@ -50,18 +48,17 @@ impl AssignmentRecordRepositorySqlImpl {
     }
 }
 
-#[async_trait]
 impl AssignmentRecordRepository for AssignmentRecordRepositorySqlImpl {
-    async fn insert (
+    fn insert (
         &self,
-        pair_id: &Uuid,
-        locker_id: &String,
-        year: &i32,
+        pair_id: Uuid,
+        locker_id: String,
+        year: i32,
     ) -> Result<AssignmentRecord, Error> {
         let new_assignmentrecord = NewAssignmentRecord {
-            pair_id,
-            locker_id,
-            year,
+            pair_id: &pair_id,
+            locker_id: &locker_id,
+            year: &year
         };
         let mut conn = self.pool.get().unwrap();
         diesel::insert_into(assignment_record::table)
@@ -69,7 +66,7 @@ impl AssignmentRecordRepository for AssignmentRecordRepositorySqlImpl {
             .get_result(&mut conn)
     }
 
-    async fn get_all(
+    fn get_all(
         &self,
     ) -> Result<Vec<AssignmentRecord>, Error> {
         let mut conn = self.pool.get().unwrap();
@@ -77,11 +74,11 @@ impl AssignmentRecordRepository for AssignmentRecordRepositorySqlImpl {
             .get_results(&mut conn)
     }
 
-    async fn get (
+    fn get (
         &self,
-        year: &i32,
-        floor: &String,
-        pair_id: &Uuid,
+        year: i32,
+        floor: String,
+        pair_id: Uuid,
     ) -> Result<Vec<AssignmentRecord>, Error> {
         let mut conn = self.pool.get().unwrap();
 
@@ -94,10 +91,10 @@ impl AssignmentRecordRepository for AssignmentRecordRepositorySqlImpl {
         ).get_results(&mut conn)
     }
 
-    async  fn get_by_pair_id(
+    fn get_by_pair_id(
             &self,
-            year: &i32,
-            pair_id: &Uuid,
+            year: i32,
+            pair_id: Uuid,
         ) -> Result<AssignmentRecord, Error> {
         let mut conn = self.pool.get().unwrap();
 
@@ -106,7 +103,7 @@ impl AssignmentRecordRepository for AssignmentRecordRepositorySqlImpl {
             .get_result(&mut conn)
     }
 
-    async fn delete_all(
+    fn delete_all(
         &self
     ) -> Result<usize, Error> {
         let mut conn = self.pool.get().unwrap();

--- a/src/adapters/repository/assignment_record.rs
+++ b/src/adapters/repository/assignment_record.rs
@@ -1,11 +1,11 @@
 use diesel::pg::PgConnection;
 use diesel::prelude::*;
-use diesel::result::Error;
 use uuid::Uuid;
 
 use crate::infrastructure::schema::*;
 use crate::infrastructure::models::*;
 use crate::infrastructure::router::Pool;
+use super::RepositoryError;
 
 /// # assignment_record
 pub trait AssignmentRecordRepository: Send + Sync {
@@ -14,28 +14,28 @@ pub trait AssignmentRecordRepository: Send + Sync {
         pair_id: Uuid,
         locker_id: String,
         year: i32,
-    ) -> Result<AssignmentRecord, Error>;
+    ) -> Result<AssignmentRecord, RepositoryError>;
 
     fn get_all(
         &self,
-    ) -> Result<Vec<AssignmentRecord>, Error>;
+    ) -> Result<Vec<AssignmentRecord>, RepositoryError>;
 
     fn get(
         &self,
         year: i32,
         floor: String,
         pair_id: Uuid,
-    ) -> Result<Vec<AssignmentRecord>, Error>;
+    ) -> Result<Vec<AssignmentRecord>, RepositoryError>;
 
     fn get_by_pair_id(
         &self,
         year: i32,
         pair_id: Uuid,
-    ) -> Result<AssignmentRecord, Error>;
+    ) -> Result<AssignmentRecord, RepositoryError>;
 
     fn delete_all(
         &self
-    ) -> Result<usize, Error>;
+    ) -> Result<usize, RepositoryError>;
 }
 
 pub struct AssignmentRecordRepositorySqlImpl {
@@ -54,24 +54,28 @@ impl AssignmentRecordRepository for AssignmentRecordRepositorySqlImpl {
         pair_id: Uuid,
         locker_id: String,
         year: i32,
-    ) -> Result<AssignmentRecord, Error> {
+    ) -> Result<AssignmentRecord, RepositoryError> {
         let new_assignmentrecord = NewAssignmentRecord {
             pair_id: &pair_id,
             locker_id: &locker_id,
             year: &year
         };
-        let mut conn = self.pool.get().unwrap();
-        diesel::insert_into(assignment_record::table)
+        let mut conn = self.pool.get()?;
+        let result = diesel::insert_into(assignment_record::table)
             .values(&new_assignmentrecord)
-            .get_result(&mut conn)
+            .get_result::<AssignmentRecord>(&mut conn)?;
+
+        Ok(result)
     }
 
     fn get_all(
         &self,
-    ) -> Result<Vec<AssignmentRecord>, Error> {
-        let mut conn = self.pool.get().unwrap();
-        assignment_record::table
-            .get_results(&mut conn)
+    ) -> Result<Vec<AssignmentRecord>, RepositoryError> {
+        let mut conn = self.pool.get()?;
+        let result = assignment_record::table
+            .get_results::<AssignmentRecord>(&mut conn)?;
+
+        Ok(result)
     }
 
     fn get (
@@ -79,35 +83,41 @@ impl AssignmentRecordRepository for AssignmentRecordRepositorySqlImpl {
         year: i32,
         floor: String,
         pair_id: Uuid,
-    ) -> Result<Vec<AssignmentRecord>, Error> {
-        let mut conn = self.pool.get().unwrap();
+    ) -> Result<Vec<AssignmentRecord>, RepositoryError> {
+        let mut conn = self.pool.get()?;
 
         let floor_ex = format!("{}%", floor);
 
-        assignment_record::table
-        .filter(assignment_record::locker_id
-            .like(floor_ex)
-        ).filter(assignment_record::pair_id.eq(pair_id).and(assignment_record::year.eq(year))
-        ).get_results(&mut conn)
+        let result = assignment_record::table
+            .filter(assignment_record::locker_id
+                .like(floor_ex)
+            ).filter(assignment_record::pair_id.eq(pair_id).and(assignment_record::year.eq(year))
+            ).get_results::<AssignmentRecord>(&mut conn)?;
+
+        Ok(result)
     }
 
     fn get_by_pair_id(
             &self,
             year: i32,
             pair_id: Uuid,
-        ) -> Result<AssignmentRecord, Error> {
-        let mut conn = self.pool.get().unwrap();
+        ) -> Result<AssignmentRecord, RepositoryError> {
+        let mut conn = self.pool.get()?;
 
-        assignment_record::table
+        let result = assignment_record::table
             .filter(assignment_record::pair_id.eq(pair_id).and(assignment_record::year.eq(year)))
-            .get_result(&mut conn)
+            .get_result::<AssignmentRecord>(&mut conn)?;
+
+        Ok(result)
     }
 
     fn delete_all(
         &self
-    ) -> Result<usize, Error> {
-        let mut conn = self.pool.get().unwrap();
-        diesel::delete(assignment_record::table)
-            .execute(&mut conn)
+    ) -> Result<usize, RepositoryError> {
+        let mut conn = self.pool.get()?;
+        let result = diesel::delete(assignment_record::table)
+            .execute(&mut conn)?;
+
+        Ok(result)
     }
 }

--- a/src/adapters/repository/auth.rs
+++ b/src/adapters/repository/auth.rs
@@ -2,35 +2,37 @@ use diesel::pg::PgConnection;
 use diesel::prelude::*;
 use diesel::result::Error;
 use uuid::Uuid;
-use async_trait::async_trait;
 
 use crate::infrastructure::schema::*;
 use crate::infrastructure::models::*;
 use crate::infrastructure::router::Pool;
 
 /// # auth
-#[async_trait]
 pub trait AuthRepository: Send + Sync {
-    async fn insert (
+    fn insert (
         &self,
-        main_auth_token: &String,
-        co_auth_token: &String,
-        phase: &String,
+        main_auth_token: String,
+        co_auth_token: String,
+        phase: String,
     ) -> Result<Auth, Error>;
-    async fn get_by_token(
+
+    fn get_by_token(
         &self,
-        auth_token: &String,
+        auth_token: String,
     ) -> Result<Auth, Error>;
-    async fn update_phase(
+
+    fn update_phase(
         &self,
-        auth_id: &Uuid,
-        phase: &String,
+        auth_id: Uuid,
+        phase: String,
     ) -> Result<usize, Error>;
-    async fn delete(
+
+    fn delete(
         &self,
-        auth_ud: &Uuid,
+        auth_ud: Uuid,
     ) -> Result<usize, Error>;
-    async fn delete_all(
+
+    fn delete_all(
         &self
     ) -> Result<usize, Error>;
 }
@@ -45,18 +47,17 @@ impl AuthRepositorySqlImpl {
     }
 }
 
-#[async_trait]
 impl AuthRepository for AuthRepositorySqlImpl {
-    async fn insert(
+    fn insert(
         &self,
-        main_auth_token: &String,
-        co_auth_token: &String,
-        phase: &String,
+        main_auth_token: String,
+        co_auth_token: String,
+        phase: String,
     ) -> Result<Auth, Error> {
         let new_auth = NewAuth {
-            main_auth_token,
-            co_auth_token,
-            phase,
+            main_auth_token: &main_auth_token,
+            co_auth_token: &co_auth_token,
+            phase: &phase,
         };
         let mut conn = self.pool.get().unwrap();
         diesel::insert_into(auth::table)
@@ -64,24 +65,24 @@ impl AuthRepository for AuthRepositorySqlImpl {
             .get_result(&mut conn)
     }
 
-    async fn get_by_token(
+    fn get_by_token(
         &self,
-        auth_token: &String,
+        auth_token: String,
     ) -> Result<Auth, Error> {
         let mut conn = self.pool.get().unwrap();
         auth::table
             .filter(
                 auth::main_auth_token
-                    .eq(auth_token)
+                    .eq(auth_token.clone())
                     .or(auth::co_auth_token.eq(auth_token)),
             )
             .first(&mut conn)
     }
 
-    async fn update_phase(
+    fn update_phase(
             &self,
-            auth_id: &Uuid,
-            phase: &String,
+            auth_id: Uuid,
+            phase: String,
         ) -> Result<usize, Error> {
         let mut conn = self.pool.get().unwrap();
         diesel::update(auth::table.find(auth_id))
@@ -89,16 +90,16 @@ impl AuthRepository for AuthRepositorySqlImpl {
             .execute(&mut conn)
     }
 
-    async fn delete(
+    fn delete(
             &self,
-            auth_id: &Uuid
+            auth_id: Uuid
         ) -> Result<usize, Error> {
         let mut conn = self.pool.get().unwrap();
         diesel::delete(auth::table.find(auth_id))
             .execute(&mut conn)
     }
 
-    async fn delete_all(
+    fn delete_all(
         &self
     ) -> Result<usize, Error> {
         let mut conn = self.pool.get().unwrap();

--- a/src/adapters/repository/circle_auth_info.rs
+++ b/src/adapters/repository/circle_auth_info.rs
@@ -2,44 +2,45 @@ use diesel::pg::PgConnection;
 use diesel::prelude::*;
 use diesel::result::Error;
 use uuid::Uuid;
-use async_trait::async_trait;
 
 use crate::infrastructure::schema::*;
 use crate::infrastructure::models::*;
 use crate::infrastructure::router::Pool;
 
 /// # circle_auth_info
-#[async_trait]
 pub trait CircleAuthInfoRepository: Send + Sync {
-    async fn insert(
+    fn insert(
         &self,
-        auth_id: &Uuid,
-        main_student_id: &String,
-        main_family_name: &String,
-        main_given_name: &String,
-        main_email: &String,
-        main_phone: &String,
-        co_student_id: &String,
-        co_family_name: &String,
-        co_given_name: &String,
-        co_email: &String,
-        co_phone: &String,
-        b_url: &String,
-        c_url: &String,
-        d_url: &String,
-        organization_name: &String,
-        organization_ruby: &String,
-        organization_email: &String,
+        auth_id: Uuid,
+        main_student_id: String,
+        main_family_name: String,
+        main_given_name: String,
+        main_email: String,
+        main_phone: String,
+        co_student_id: String,
+        co_family_name: String,
+        co_given_name: String,
+        co_email: String,
+        co_phone: String,
+        b_url: String,
+        c_url: String,
+        d_url: String,
+        organization_name: String,
+        organization_ruby: String,
+        organization_email: String,
     ) -> Result<CircleAuthInfo, Error>;
-    async fn get_by_id(
+
+    fn get_by_id(
         &self,
-        auth_id: &Uuid,
+        auth_id: Uuid,
     ) -> Result<CircleAuthInfo, Error>;
-    async fn delete(
+
+    fn delete(
         &self,
-        auth_id: &Uuid,
+        auth_id: Uuid,
     ) -> Result<usize, Error>;
-    async fn delete_all(
+
+    fn delete_all(
         &self
     ) -> Result<usize, Error>;
 }
@@ -54,69 +55,68 @@ impl CircleAuthInfoRepositorySqlImpl {
     }
 }
 
-#[async_trait]
 impl CircleAuthInfoRepository for CircleAuthInfoRepositorySqlImpl {
-    async fn insert(
+    fn insert(
             &self,
-            auth_id: &Uuid,
-            main_student_id: &String,
-            main_family_name: &String,
-            main_given_name: &String,
-            main_email: &String,
-            main_phone: &String,
-            co_student_id: &String,
-            co_family_name: &String,
-            co_given_name: &String,
-            co_email: &String,
-            co_phone: &String,
-            b_doc: &String,
-            c_doc: &String,
-            d_doc: &String,
-            organization_name: &String,
-            organization_ruby: &String,
-            organization_email: &String,
+            auth_id: Uuid,
+            main_student_id: String,
+            main_family_name: String,
+            main_given_name: String,
+            main_email: String,
+            main_phone: String,
+            co_student_id: String,
+            co_family_name: String,
+            co_given_name: String,
+            co_email: String,
+            co_phone: String,
+            b_doc: String,
+            c_doc: String,
+            d_doc: String,
+            organization_name: String,
+            organization_ruby: String,
+            organization_email: String,
     ) -> Result<CircleAuthInfo, Error> {
         let new_auth_info = NewCircleAuthInfo {
-            auth_id: auth_id,
-            main_student_id: main_student_id,
-            main_family_name: main_family_name,
-            main_given_name: main_given_name,
-            main_email: main_email,
-            main_phone: main_phone,
-            co_student_id: co_student_id,
-            co_family_name: co_family_name,
-            co_given_name: co_given_name,
-            co_email: co_email,
-            co_phone: co_phone,
-            b_doc: b_doc,
-            c_doc: c_doc,
-            d_doc: d_doc,
-            organization_name: organization_name,
-            organization_ruby: organization_ruby,
-            organization_email: organization_email,
+            auth_id: &auth_id,
+            main_student_id: &main_student_id,
+            main_family_name: &main_family_name,
+            main_given_name: &main_given_name,
+            main_email: &main_email,
+            main_phone: &main_phone,
+            co_student_id: &co_student_id,
+            co_family_name: &co_family_name,
+            co_given_name: &co_given_name,
+            co_email: &co_email,
+            co_phone: &co_phone,
+            b_doc: &b_doc,
+            c_doc: &c_doc,
+            d_doc: &d_doc,
+            organization_name: &organization_name,
+            organization_ruby: &organization_ruby,
+            organization_email: &organization_email,
         };
         let mut conn = self.pool.get().unwrap();
         diesel::insert_into(circle_auth_info::table)
             .values(&new_auth_info)
             .get_result(&mut conn)
     }
-    async fn get_by_id(
+    fn get_by_id(
             &self,
-            auth_id: &Uuid,
+            auth_id: Uuid,
         ) -> Result<CircleAuthInfo, Error> {
             let mut conn = self.pool.get().unwrap();
         circle_auth_info::table.filter(circle_auth_info::auth_id.eq(auth_id))
             .get_result(&mut conn)
     }
-    async fn delete(
+    fn delete(
             &self,
-            auth_id: &Uuid,
+            auth_id: Uuid,
         ) -> Result<usize, Error> {
         let mut conn = self.pool.get().unwrap();
         diesel::delete(circle_auth_info::table.find(auth_id))
             .execute(&mut conn)
     }
-    async fn delete_all(
+    fn delete_all(
             &self
         ) -> Result<usize, Error> {
         let mut conn = self.pool.get().unwrap();

--- a/src/adapters/repository/locker.rs
+++ b/src/adapters/repository/locker.rs
@@ -1,60 +1,58 @@
 use diesel::pg::PgConnection;
 use diesel::prelude::*;
 use diesel::result::Error;
-use async_trait::async_trait;
 
 use crate::infrastructure::schema::*;
 use crate::infrastructure::models::*;
 use crate::infrastructure::router::Pool;
 
 /// # locker
-#[async_trait]
 pub trait LockerRepository: Send + Sync {
-    async fn insert(
+    fn insert(
         &self,
-        locker_id: &String,
-        location: &String,
-        status: &String,
+        locker_id: String,
+        location: String,
+        status: String,
     ) -> Result<Locker, Error>;
 
-    async fn get_all(
+    fn get_all(
         &self,
     ) -> Result<Vec<Locker>, Error>;
 
-    async fn update_status(
+    fn update_status(
         &self,
-        floor: &String,
-        prev_status: &String,
-        new_status: &String,
+        floor: String,
+        prev_status: String,
+        new_status: String,
     ) -> Result<usize, Error>;
 
-    async fn update_status_by_id(
+    fn update_status_by_id(
         &self,
-        locker_id: &String,
-        status: &String,
+        locker_id: String,
+        status: String,
     ) -> Result<usize, Error>;
 
-    async fn update_all_status(
+    fn update_all_status(
         &self,
-        status: &String,
+        status: String,
     ) -> Result<usize, Error>;
 
-    async fn get_by_id(
+    fn get_by_id(
         &self,
-        locker_id: &String,
+        locker_id: String,
     ) -> Result<Locker, Error>;
 
-    async fn get_by_floor(
+    fn get_by_floor(
         &self,
-        floor: &String,
+        floor: String,
     ) -> Result<Vec<Locker>, Error>;
 
-    async fn get_by_status(
+    fn get_by_status(
         &self,
-        status: &String,
+        status: String,
     ) -> Result<Vec<Locker>, Error>;
 
-    async fn delete_all(
+    fn delete_all(
         &self
     ) -> Result<usize, Error>;
 }
@@ -69,18 +67,17 @@ impl LockerRepositorySqlImpl {
     }
 }
 
-#[async_trait]
 impl LockerRepository for LockerRepositorySqlImpl {
-    async fn insert(
+    fn insert(
         &self,
-        locker_id: &String,
-        location: &String,
-        status: &String,
+        locker_id: String,
+        location: String,
+        status: String,
     ) -> Result<Locker, Error> {
         let new_locker = NewLocker {
-            locker_id,
-            location,
-            status
+            locker_id: &locker_id,
+            location: &location,
+            status: &status
         };
         let mut conn = self.pool.get().unwrap();
         diesel::insert_into(locker::table)
@@ -88,7 +85,7 @@ impl LockerRepository for LockerRepositorySqlImpl {
             .get_result(&mut conn)
     }
 
-    async fn get_all(
+    fn get_all(
         &self,
     ) -> Result<Vec<Locker>, Error> {
         let mut conn = self.pool.get().unwrap();
@@ -96,11 +93,11 @@ impl LockerRepository for LockerRepositorySqlImpl {
             .get_results(&mut conn)
     }
 
-    async  fn update_status(
+    fn update_status(
             &self,
-            floor: &String,
-            prev_status: &String,
-            new_status: &String,
+            floor: String,
+            prev_status: String,
+            new_status: String,
         ) -> Result<usize, Error> {
         let mut conn = self.pool.get().unwrap();
         let floor_ex = format!("{}%", floor);
@@ -113,10 +110,10 @@ impl LockerRepository for LockerRepositorySqlImpl {
         .execute(&mut conn)
     }
 
-    async fn update_status_by_id(
+    fn update_status_by_id(
             &self,
-            locker_id: &String,
-            status: &String,
+            locker_id: String,
+            status: String,
         ) -> Result<usize, Error> {
         let mut conn = self.pool.get().unwrap();
         diesel::update(locker::table.find(locker_id))
@@ -124,9 +121,9 @@ impl LockerRepository for LockerRepositorySqlImpl {
             .execute(&mut conn)
     }
 
-    async fn update_all_status(
+    fn update_all_status(
             &self,
-            status: &String,
+            status: String,
         ) -> Result<usize, Error> {
         let mut conn = self.pool.get().unwrap();
         diesel::update(locker::table)
@@ -134,9 +131,9 @@ impl LockerRepository for LockerRepositorySqlImpl {
             .execute(&mut conn)
     }
 
-    async  fn get_by_id(
+    fn get_by_id(
             &self,
-            locker_id: &String,
+            locker_id: String,
         ) -> Result<Locker, Error> {
             let mut conn = self.pool.get().unwrap();
         locker::table
@@ -146,9 +143,9 @@ impl LockerRepository for LockerRepositorySqlImpl {
             ).first(&mut conn)
     }
 
-    async fn get_by_floor(
+    fn get_by_floor(
             &self,
-            floor: &String,
+            floor: String,
         ) -> Result<Vec<Locker>, Error> {
         let mut conn = self.pool.get().unwrap();
         let floor_ex = format!("{}%", floor);
@@ -159,9 +156,9 @@ impl LockerRepository for LockerRepositorySqlImpl {
             ).get_results(&mut conn)
     }
 
-    async fn get_by_status(
+    fn get_by_status(
             &self,
-            status: &String,
+            status: String,
         ) -> Result<Vec<Locker>, Error> {
         let mut conn = self.pool.get().unwrap();
         locker::table
@@ -170,7 +167,7 @@ impl LockerRepository for LockerRepositorySqlImpl {
             ).get_results(&mut conn)
     }
 
-    async fn delete_all(
+    fn delete_all(
         &self
     ) -> Result<usize, Error> {
         let mut conn = self.pool.get().unwrap();

--- a/src/adapters/repository/locker_auth_info.rs
+++ b/src/adapters/repository/locker_auth_info.rs
@@ -2,34 +2,35 @@ use diesel::pg::PgConnection;
 use diesel::prelude::*;
 use diesel::result::Error;
 use uuid::Uuid;
-use async_trait::async_trait;
 
 use crate::infrastructure::schema::*;
 use crate::infrastructure::models::*;
 use crate::infrastructure::router::Pool;
 
 /// # locker_auth_info
-#[async_trait]
 pub trait LockerAuthInfoRepository: Send + Sync {
-    async fn insert(
+    fn insert(
         &self,
-        auth_id: &Uuid,
-        main_student_id: &String,
-        main_family_name: &String,
-        main_given_name: &String,
-        co_student_id: &String,
-        co_family_name: &String,
-        co_given_name: &String,
+        auth_id: Uuid,
+        main_student_id: String,
+        main_family_name: String,
+        main_given_name: String,
+        co_student_id: String,
+        co_family_name: String,
+        co_given_name: String,
     ) -> Result<LockerAuthInfo, Error>;
-    async fn get_by_id(
+
+    fn get_by_id(
         &self,
-        auth_id: &Uuid,
+        auth_id: Uuid,
     ) -> Result<LockerAuthInfo, Error>;
-    async fn delete(
+
+    fn delete(
         &self,
-        auth_id: &Uuid,
+        auth_id: Uuid,
     ) -> Result<usize, Error>;
-    async fn delete_all(
+
+    fn delete_all(
         &self
     ) -> Result<usize, Error>;
 }
@@ -44,49 +45,51 @@ impl LockerAuthInfoRepositorySqlImpl {
     }
 }
 
-#[async_trait]
 impl LockerAuthInfoRepository for LockerAuthInfoRepositorySqlImpl {
-    async fn insert(
+    fn insert(
             &self,
-            auth_id: &Uuid,
-            main_student_id: &String,
-            main_family_name: &String,
-            main_given_name: &String,
-            co_student_id: &String,
-            co_family_name: &String,
-            co_given_name: &String,
+            auth_id: Uuid,
+            main_student_id: String,
+            main_family_name: String,
+            main_given_name: String,
+            co_student_id: String,
+            co_family_name: String,
+            co_given_name: String,
     ) -> Result<LockerAuthInfo, Error> {
         let new_auth_info = NewLockerAuthInfo {
-            auth_id: auth_id,
-            main_student_id: main_student_id,
-            main_family_name: main_family_name,
-            main_given_name: main_given_name,
-            co_student_id: co_student_id,
-            co_family_name: co_family_name,
-            co_given_name: co_given_name,
+            auth_id: &auth_id,
+            main_student_id: &main_student_id,
+            main_family_name: &main_family_name,
+            main_given_name: &main_given_name,
+            co_student_id: &co_student_id,
+            co_family_name: &co_family_name,
+            co_given_name: &co_given_name,
         };
         let mut conn = self.pool.get().unwrap();
         diesel::insert_into(locker_auth_info::table)
             .values(&new_auth_info)
             .get_result(&mut conn)
     }
-    async fn get_by_id(
+
+    fn get_by_id(
             &self,
-            auth_id: &Uuid,
+            auth_id: Uuid,
         ) -> Result<LockerAuthInfo, Error> {
             let mut conn = self.pool.get().unwrap();
         locker_auth_info::table.filter(locker_auth_info::auth_id.eq(auth_id))
             .get_result(&mut conn)
     }
-    async fn delete(
+
+    fn delete(
             &self,
-            auth_id: &Uuid,
+            auth_id: Uuid,
         ) -> Result<usize, Error> {
         let mut conn = self.pool.get().unwrap();
         diesel::delete(locker_auth_info::table.find(auth_id))
             .execute(&mut conn)
     }
-    async fn delete_all(
+
+    fn delete_all(
             &self
         ) -> Result<usize, Error> {
         let mut conn = self.pool.get().unwrap();

--- a/src/adapters/repository/organization.rs
+++ b/src/adapters/repository/organization.rs
@@ -1,35 +1,33 @@
 use diesel::pg::PgConnection;
 use diesel::prelude::*;
 use diesel::result::Error;
-use async_trait::async_trait;
 
 use crate::infrastructure::schema::*;
 use crate::infrastructure::models::*;
 use crate::infrastructure::router::Pool;
 
 /// # organization
-#[async_trait]
 pub trait OrganizationRepository: Send + Sync {
-    async fn insert(
+    fn insert(
         &self,
-        organization_name: &String,
-        organization_ruby: &String,
-        organization_email: &String,
+        organization_name: String,
+        organization_ruby: String,
+        organization_email: String,
     ) -> Result<Organization, Error>;
 
-    async fn get_all(
+    fn get_all(
         &self,
     ) -> Result<Vec<Organization>, Error>;
 
-    async fn get_by_id(
+    fn get_by_id(
         &self,
-        organization_id: &i32,
+        organization_id: i32,
     ) -> Result<Organization, Error>;
 
-    async fn update_email_by_id(
+    fn update_email_by_id(
         &self,
-        organization_id: &i32,
-        organization_email: &String,
+        organization_id: i32,
+        organization_email: String,
     ) -> Result<Organization, Error>;
 }
 
@@ -43,18 +41,17 @@ impl OrganizationRepositorySqlImpl {
     }
 }
 
-#[async_trait]
 impl OrganizationRepository for OrganizationRepositorySqlImpl {
-    async fn insert(
+    fn insert(
             &self,
-            organization_name: &String,
-            organization_ruby: &String,
-            organization_email: &String,
+            organization_name: String,
+            organization_ruby: String,
+            organization_email: String,
         ) -> Result<Organization, Error> {
         let new_organization = NewOrganization{
-            organization_name: organization_name,
-            organization_ruby: organization_ruby,
-            organization_email: organization_email,
+            organization_name: &organization_name,
+            organization_ruby: &organization_ruby,
+            organization_email: &organization_email,
         };
         let mut conn = self.pool.get().unwrap();
         diesel::insert_into(organization::table)
@@ -62,7 +59,7 @@ impl OrganizationRepository for OrganizationRepositorySqlImpl {
             .get_result(&mut conn)
     }
 
-    async fn get_all(
+    fn get_all(
             &self,
         ) -> Result<Vec<Organization>, Error> {
         let mut conn = self.pool.get().unwrap();
@@ -70,19 +67,19 @@ impl OrganizationRepository for OrganizationRepositorySqlImpl {
             .get_results(&mut conn)
     }
 
-    async  fn get_by_id(
+    fn get_by_id(
             &self,
-            organization_id: &i32,
+            organization_id: i32,
         ) -> Result<Organization, Error> {
         let mut conn = self.pool.get().unwrap();
         organization::table.filter(organization::organization_id.eq(organization_id))
             .get_result(&mut conn)
     }
 
-    async fn update_email_by_id(
+    fn update_email_by_id(
             &self,
-            organization_id: &i32,
-            organization_email: &String,
+            organization_id: i32,
+            organization_email: String,
         ) -> Result<Organization, Error> {
         let mut conn = self.pool.get().unwrap();
         diesel::update(organization::table)

--- a/src/adapters/repository/organization.rs
+++ b/src/adapters/repository/organization.rs
@@ -1,10 +1,10 @@
 use diesel::pg::PgConnection;
 use diesel::prelude::*;
-use diesel::result::Error;
 
 use crate::infrastructure::schema::*;
 use crate::infrastructure::models::*;
 use crate::infrastructure::router::Pool;
+use super::RepositoryError;
 
 /// # organization
 pub trait OrganizationRepository: Send + Sync {
@@ -13,22 +13,22 @@ pub trait OrganizationRepository: Send + Sync {
         organization_name: String,
         organization_ruby: String,
         organization_email: String,
-    ) -> Result<Organization, Error>;
+    ) -> Result<Organization, RepositoryError>;
 
     fn get_all(
         &self,
-    ) -> Result<Vec<Organization>, Error>;
+    ) -> Result<Vec<Organization>, RepositoryError>;
 
     fn get_by_id(
         &self,
         organization_id: i32,
-    ) -> Result<Organization, Error>;
+    ) -> Result<Organization, RepositoryError>;
 
     fn update_email_by_id(
         &self,
         organization_id: i32,
         organization_email: String,
-    ) -> Result<Organization, Error>;
+    ) -> Result<Organization, RepositoryError>;
 }
 
 pub struct OrganizationRepositorySqlImpl {
@@ -47,44 +47,52 @@ impl OrganizationRepository for OrganizationRepositorySqlImpl {
             organization_name: String,
             organization_ruby: String,
             organization_email: String,
-        ) -> Result<Organization, Error> {
+        ) -> Result<Organization, RepositoryError> {
         let new_organization = NewOrganization{
             organization_name: &organization_name,
             organization_ruby: &organization_ruby,
             organization_email: &organization_email,
         };
-        let mut conn = self.pool.get().unwrap();
-        diesel::insert_into(organization::table)
+        let mut conn = self.pool.get()?;
+        let result = diesel::insert_into(organization::table)
             .values(new_organization)
-            .get_result(&mut conn)
+            .get_result::<Organization>(&mut conn)?;
+
+        Ok(result)
     }
 
     fn get_all(
             &self,
-        ) -> Result<Vec<Organization>, Error> {
-        let mut conn = self.pool.get().unwrap();
-        organization::table
-            .get_results(&mut conn)
+        ) -> Result<Vec<Organization>, RepositoryError> {
+        let mut conn = self.pool.get()?;
+        let result = organization::table
+            .get_results::<Organization>(&mut conn)?;
+
+        Ok(result)
     }
 
     fn get_by_id(
             &self,
             organization_id: i32,
-        ) -> Result<Organization, Error> {
-        let mut conn = self.pool.get().unwrap();
-        organization::table.filter(organization::organization_id.eq(organization_id))
-            .get_result(&mut conn)
+        ) -> Result<Organization, RepositoryError> {
+        let mut conn = self.pool.get()?;
+        let result = organization::table.filter(organization::organization_id.eq(organization_id))
+            .get_result::<Organization>(&mut conn)?;
+
+        Ok(result)
     }
 
     fn update_email_by_id(
             &self,
             organization_id: i32,
             organization_email: String,
-        ) -> Result<Organization, Error> {
-        let mut conn = self.pool.get().unwrap();
-        diesel::update(organization::table)
+        ) -> Result<Organization, RepositoryError> {
+        let mut conn = self.pool.get()?;
+        let result = diesel::update(organization::table)
             .filter(organization::organization_id.eq(organization_id))
             .set((organization::organization_email.eq(organization_email), organization::updated_at.eq(diesel::dsl::now)))
-            .get_result(&mut conn)
+            .get_result::<Organization>(&mut conn)?;
+
+        Ok(result)
     }
 }

--- a/src/adapters/repository/registration.rs
+++ b/src/adapters/repository/registration.rs
@@ -1,10 +1,10 @@
 use diesel::pg::PgConnection;
 use diesel::prelude::*;
-use diesel::result::Error;
 
 use crate::infrastructure::schema::*;
 use crate::infrastructure::models::*;
 use crate::infrastructure::router::Pool;
+use super::RepositoryError;
 
 /// # registration
 pub trait RegistrationRepository: Send + Sync {
@@ -21,14 +21,14 @@ pub trait RegistrationRepository: Send + Sync {
         b_url: String,
         c_url: String,
         d_url: String,
-    ) -> Result<Registration, Error>;
+    ) -> Result<Registration, RepositoryError>;
 
     fn update_student_by_id (
         &self,
         organization_id: i32,
         main_student_id: String,
         co_student_id: String,
-    ) -> Result<Registration, Error>;
+    ) -> Result<Registration, RepositoryError>;
 
     fn update_status_by_id (
         &self,
@@ -37,11 +37,11 @@ pub trait RegistrationRepository: Send + Sync {
         status_authentication: String,
         status_form_confirmation: String,
         status_registration_complete: String,
-    ) -> Result<Registration, Error>;
+    ) -> Result<Registration, RepositoryError>;
 
     fn get_all (
         &self,
-    ) -> Result<Vec<Registration>, Error>;
+    ) -> Result<Vec<Registration>, RepositoryError>;
 
 
 }
@@ -70,8 +70,8 @@ impl RegistrationRepository for RegistrationRepositorySqlImpl {
             b_doc: String,
             c_doc: String,
             d_doc: String,
-        ) -> Result<Registration, Error> {
-        let mut conn = self.pool.get().unwrap();
+        ) -> Result<Registration, RepositoryError> {
+        let mut conn = self.pool.get()?;
         let new_registration = NewRegistration{
             organization_id: &organization_id,
             year: &year,
@@ -85,9 +85,11 @@ impl RegistrationRepository for RegistrationRepositorySqlImpl {
             c_doc: &c_doc,
             d_doc: &d_doc,
         };
-        diesel::insert_into(registration::table)
+        let result = diesel::insert_into(registration::table)
             .values(new_registration)
-            .get_result(&mut conn)
+            .get_result::<Registration>(&mut conn)?;
+
+        Ok(result)
     }
 
     fn update_student_by_id (
@@ -95,12 +97,14 @@ impl RegistrationRepository for RegistrationRepositorySqlImpl {
             organization_id: i32,
             main_student_id: String,
             co_student_id: String,
-        ) -> Result<Registration, Error> {
-        let mut conn = self.pool.get().unwrap();
-        diesel::update(registration::table)
+        ) -> Result<Registration, RepositoryError> {
+        let mut conn = self.pool.get()?;
+        let result = diesel::update(registration::table)
             .filter(registration::organization_id.eq(organization_id))
             .set((registration::main_student_id.eq(main_student_id), registration::co_student_id.eq(co_student_id), registration::updated_at.eq(diesel::dsl::now)))
-            .get_result(&mut conn)
+            .get_result::<Registration>(&mut conn)?;
+
+        Ok(result)
     }
 
     fn update_status_by_id (
@@ -110,18 +114,22 @@ impl RegistrationRepository for RegistrationRepositorySqlImpl {
             status_authentication: String,
             status_form_confirmation: String,
             status_registration_complete: String,
-        ) -> Result<Registration, Error> {
-        let mut conn = self.pool.get().unwrap();
-        diesel::update(registration::table)
+        ) -> Result<Registration, RepositoryError> {
+        let mut conn = self.pool.get()?;
+        let result = diesel::update(registration::table)
             .filter(registration::organization_id.eq(organization_id))
             .set((registration::status_acceptance.eq(status_acceptance), registration::status_authentication.eq(status_authentication), registration::status_form_confirmation.eq(status_form_confirmation), registration::status_registration_complete.eq(status_registration_complete)))
-            .get_result(&mut conn)
+            .get_result::<Registration>(&mut conn)?;
+
+        Ok(result)
     }
 
     fn get_all (
             &self,
-        ) -> Result<Vec<Registration>, Error> {
-        let mut conn = self.pool.get().unwrap();
-        registration::table.get_results(&mut conn)
+        ) -> Result<Vec<Registration>, RepositoryError> {
+        let mut conn = self.pool.get()?;
+        let result = registration::table.get_results::<Registration>(&mut conn)?;
+
+        Ok(result)
     }
 }

--- a/src/adapters/repository/registration.rs
+++ b/src/adapters/repository/registration.rs
@@ -1,47 +1,45 @@
 use diesel::pg::PgConnection;
 use diesel::prelude::*;
 use diesel::result::Error;
-use async_trait::async_trait;
 
 use crate::infrastructure::schema::*;
 use crate::infrastructure::models::*;
 use crate::infrastructure::router::Pool;
 
 /// # registration
-#[async_trait]
 pub trait RegistrationRepository: Send + Sync {
-    async fn insert(
+    fn insert(
         &self,
-        organization_id: &i32,
-        year: &i32,
-        main_student_id: &String,
-        co_student_id: &String,
-        status_acceptance: &String,
-        status_authentication: &String,
-        status_form_confirmation: &String,
-        status_registration_complete: &String,
-        b_url: &String,
-        c_url: &String,
-        d_url: &String,
+        organization_id: i32,
+        year: i32,
+        main_student_id: String,
+        co_student_id: String,
+        status_acceptance: String,
+        status_authentication: String,
+        status_form_confirmation: String,
+        status_registration_complete: String,
+        b_url: String,
+        c_url: String,
+        d_url: String,
     ) -> Result<Registration, Error>;
 
-    async fn update_student_by_id (
+    fn update_student_by_id (
         &self,
-        organization_id: &i32,
-        main_student_id: &String,
-        co_student_id: &String,
+        organization_id: i32,
+        main_student_id: String,
+        co_student_id: String,
     ) -> Result<Registration, Error>;
 
-    async fn update_status_by_id (
+    fn update_status_by_id (
         &self,
-        organization_id: &i32,
-        status_acceptance: &String,
-        status_authentication: &String,
-        status_form_confirmation: &String,
-        status_registration_complete: &String,
+        organization_id: i32,
+        status_acceptance: String,
+        status_authentication: String,
+        status_form_confirmation: String,
+        status_registration_complete: String,
     ) -> Result<Registration, Error>;
 
-    async fn get_all (
+    fn get_all (
         &self,
     ) -> Result<Vec<Registration>, Error>;
 
@@ -58,46 +56,45 @@ impl RegistrationRepositorySqlImpl {
     }
 }
 
-#[async_trait]
 impl RegistrationRepository for RegistrationRepositorySqlImpl {
-    async fn insert(
+    fn insert(
             &self,
-            organization_id: &i32,
-            year: &i32,
-            main_student_id: &String,
-            co_student_id: &String,
-            status_acceptance: &String,
-            status_authentication: &String,
-            status_form_confirmation: &String,
-            status_registration_complete: &String,
-            b_doc: &String,
-            c_doc: &String,
-            d_doc: &String,
+            organization_id: i32,
+            year: i32,
+            main_student_id: String,
+            co_student_id: String,
+            status_acceptance: String,
+            status_authentication: String,
+            status_form_confirmation: String,
+            status_registration_complete: String,
+            b_doc: String,
+            c_doc: String,
+            d_doc: String,
         ) -> Result<Registration, Error> {
         let mut conn = self.pool.get().unwrap();
         let new_registration = NewRegistration{
-            organization_id: organization_id,
-            year: year,
-            main_student_id: main_student_id,
-            co_student_id: co_student_id,
-            status_acceptance: status_acceptance,
-            status_authentication:status_authentication,
-            status_form_confirmation: status_form_confirmation,
-            status_registration_complete: status_registration_complete,
-            b_doc: b_doc,
-            c_doc: c_doc,
-            d_doc: d_doc,
+            organization_id: &organization_id,
+            year: &year,
+            main_student_id: &main_student_id,
+            co_student_id: &co_student_id,
+            status_acceptance: &status_acceptance,
+            status_authentication: &status_authentication,
+            status_form_confirmation: &status_form_confirmation,
+            status_registration_complete: &status_registration_complete,
+            b_doc: &b_doc,
+            c_doc: &c_doc,
+            d_doc: &d_doc,
         };
         diesel::insert_into(registration::table)
             .values(new_registration)
             .get_result(&mut conn)
     }
 
-    async fn update_student_by_id (
+    fn update_student_by_id (
             &self,
-            organization_id: &i32,
-            main_student_id: &String,
-            co_student_id: &String,
+            organization_id: i32,
+            main_student_id: String,
+            co_student_id: String,
         ) -> Result<Registration, Error> {
         let mut conn = self.pool.get().unwrap();
         diesel::update(registration::table)
@@ -106,13 +103,13 @@ impl RegistrationRepository for RegistrationRepositorySqlImpl {
             .get_result(&mut conn)
     }
 
-    async fn update_status_by_id (
+    fn update_status_by_id (
             &self,
-            organization_id: &i32,
-            status_acceptance: &String,
-            status_authentication: &String,
-            status_form_confirmation: &String,
-            status_registration_complete: &String,
+            organization_id: i32,
+            status_acceptance: String,
+            status_authentication: String,
+            status_form_confirmation: String,
+            status_registration_complete: String,
         ) -> Result<Registration, Error> {
         let mut conn = self.pool.get().unwrap();
         diesel::update(registration::table)
@@ -121,7 +118,7 @@ impl RegistrationRepository for RegistrationRepositorySqlImpl {
             .get_result(&mut conn)
     }
 
-    async fn get_all (
+    fn get_all (
             &self,
         ) -> Result<Vec<Registration>, Error> {
         let mut conn = self.pool.get().unwrap();

--- a/src/adapters/repository/representatives.rs
+++ b/src/adapters/repository/representatives.rs
@@ -1,10 +1,10 @@
 use diesel::pg::PgConnection;
 use diesel::prelude::*;
-use diesel::result::Error;
 
 use crate::infrastructure::schema::*;
 use crate::infrastructure::models::*;
 use crate::infrastructure::router::Pool;
+use super::RepositoryError;
 
 /// # representatives
 pub trait RepresentativesRepository: Send + Sync {
@@ -15,16 +15,16 @@ pub trait RepresentativesRepository: Send + Sync {
         given_name: String,
         email: String,
         phone: String,
-    ) -> Result<Representatives, Error>;
+    ) -> Result<Representatives, RepositoryError>;
 
     fn get_all(
         &self,
-    ) -> Result<Vec<Representatives>, Error>;
+    ) -> Result<Vec<Representatives>, RepositoryError>;
 
     fn get_by_id(
         &self,
         student_id: String,
-    ) -> Result<Representatives, Error>;
+    ) -> Result<Representatives, RepositoryError>;
 }
 
 pub struct RepresentativesRepositorySqlImpl {
@@ -45,7 +45,7 @@ impl RepresentativesRepository for RepresentativesRepositorySqlImpl {
             given_name: String,
             email: String,
             phone: String,
-        ) -> Result<Representatives, Error> {
+        ) -> Result<Representatives, RepositoryError> {
         let new_representative = NewRepresentatives{
             student_id: &student_id,
             family_name: &family_name,
@@ -53,30 +53,36 @@ impl RepresentativesRepository for RepresentativesRepositorySqlImpl {
             email: &email.clone(),
             phone: &phone.clone(),
         };
-        let mut conn = self.pool.get().unwrap();
-        diesel::insert_into(representatives::table)
+        let mut conn = self.pool.get()?;
+        let result = diesel::insert_into(representatives::table)
             .values(new_representative)
             .on_conflict(representatives::student_id)
             .do_update()
             .set((representatives::updated_at.eq(diesel::dsl::now), representatives::email.eq(email), representatives::phone.eq(phone)))
-            .get_result(&mut conn)
+            .get_result::<Representatives>(&mut conn)?;
+
+        Ok(result)
     }
 
     fn get_all(
             &self,
-        ) -> Result<Vec<Representatives>, Error> {
-        let mut conn = self.pool.get().unwrap();
-        representatives::table
-            .get_results(&mut conn)
+        ) -> Result<Vec<Representatives>, RepositoryError> {
+        let mut conn = self.pool.get()?;
+        let result = representatives::table
+            .get_results::<Representatives>(&mut conn)?;
+
+        Ok(result)
     }
 
     fn get_by_id(
             &self,
             student_id: String,
-        ) -> Result<Representatives, Error> {
-        let mut conn = self.pool.get().unwrap();
-        representatives::table
+        ) -> Result<Representatives, RepositoryError> {
+        let mut conn = self.pool.get()?;
+        let result = representatives::table
             .filter(representatives::student_id.eq(student_id))
-            .get_result(&mut conn)
+            .get_result::<Representatives>(&mut conn)?;
+
+        Ok(result)
     }
 }

--- a/src/adapters/repository/representatives.rs
+++ b/src/adapters/repository/representatives.rs
@@ -1,31 +1,29 @@
 use diesel::pg::PgConnection;
 use diesel::prelude::*;
 use diesel::result::Error;
-use async_trait::async_trait;
 
 use crate::infrastructure::schema::*;
 use crate::infrastructure::models::*;
 use crate::infrastructure::router::Pool;
 
 /// # representatives
-#[async_trait]
 pub trait RepresentativesRepository: Send + Sync {
-    async fn insert(
+    fn insert(
         &self,
-        student_id: &String,
-        family_name: &String,
-        given_name: &String,
-        email: &String,
-        phone: &String,
+        student_id: String,
+        family_name: String,
+        given_name: String,
+        email: String,
+        phone: String,
     ) -> Result<Representatives, Error>;
 
-    async fn get_all(
+    fn get_all(
         &self,
     ) -> Result<Vec<Representatives>, Error>;
 
-    async fn get_by_id(
+    fn get_by_id(
         &self,
-        student_id: &String,
+        student_id: String,
     ) -> Result<Representatives, Error>;
 }
 
@@ -39,22 +37,21 @@ impl RepresentativesRepositorySqlImpl {
     }
 }
 
-#[async_trait]
 impl RepresentativesRepository for RepresentativesRepositorySqlImpl {
-    async fn insert(
+    fn insert(
             &self,
-            student_id: &String,
-            family_name: &String,
-            given_name: &String,
-            email: &String,
-            phone: &String,
+            student_id: String,
+            family_name: String,
+            given_name: String,
+            email: String,
+            phone: String,
         ) -> Result<Representatives, Error> {
         let new_representative = NewRepresentatives{
-            student_id: student_id,
-            family_name: family_name,
-            given_name: given_name,
-            email: email,
-            phone: phone,
+            student_id: &student_id,
+            family_name: &family_name,
+            given_name: &given_name,
+            email: &email.clone(),
+            phone: &phone.clone(),
         };
         let mut conn = self.pool.get().unwrap();
         diesel::insert_into(representatives::table)
@@ -65,7 +62,7 @@ impl RepresentativesRepository for RepresentativesRepositorySqlImpl {
             .get_result(&mut conn)
     }
 
-    async fn get_all(
+    fn get_all(
             &self,
         ) -> Result<Vec<Representatives>, Error> {
         let mut conn = self.pool.get().unwrap();
@@ -73,9 +70,9 @@ impl RepresentativesRepository for RepresentativesRepositorySqlImpl {
             .get_results(&mut conn)
     }
 
-    async fn get_by_id(
+    fn get_by_id(
             &self,
-            student_id: &String,
+            student_id: String,
         ) -> Result<Representatives, Error> {
         let mut conn = self.pool.get().unwrap();
         representatives::table

--- a/src/adapters/repository/student.rs
+++ b/src/adapters/repository/student.rs
@@ -1,7 +1,6 @@
 use diesel::pg::PgConnection;
 use diesel::prelude::*;
 use diesel::result::Error;
-use async_trait::async_trait;
 
 use crate::infrastructure::schema::*;
 use crate::infrastructure::models::*;
@@ -9,31 +8,30 @@ use crate::infrastructure::router::Pool;
 
 
 /// # student
-#[async_trait]
 pub trait StudentRepository: Send + Sync {
-    async fn insert(
+    fn insert(
         &self,
-        student_id: &String,
-        family_name: &String,
-        given_name: &String,
+        student_id: String,
+        family_name: String,
+        given_name: String,
     ) -> Result<Student, Error>;
 
-    async fn get_all(
+    fn get_all(
         &self
     ) -> Result<Vec<Student>, Error>;
 
-    async fn get_by_id(
+     fn get_by_id(
         &self,
-        student_id: &String,
+        student_id: String,
     ) -> Result<Student, Error>;
 
-    async fn get_by_name(
+     fn get_by_name(
         &self,
-        family_name: &String,
-        given_name: &String,
+        family_name: String,
+        given_name: String,
     ) -> Result<Vec<Student>, Error>;
 
-    async fn delete_all(
+     fn delete_all(
         &self
     ) -> Result<usize, Error>;
 }
@@ -47,18 +45,17 @@ impl StudentRepositorySqlImpl {
     }
 }
 
-#[async_trait]
 impl StudentRepository for StudentRepositorySqlImpl{
-    async fn insert(
+     fn insert(
         &self,
-        student_id: &String,
-        family_name: &String,
-        given_name: &String,
+        student_id: String,
+        family_name: String,
+        given_name: String,
     ) -> Result<Student, Error> {
         let new_student = NewStudent {
-            student_id,
-            family_name,
-            given_name,
+            student_id: &student_id,
+            family_name: &family_name,
+            given_name: &given_name,
         };
         let mut conn = self.pool.get().unwrap();
         diesel::insert_into(student::table)
@@ -69,7 +66,7 @@ impl StudentRepository for StudentRepositorySqlImpl{
             .get_result(&mut conn)
     }
 
-    async fn get_all(
+     fn get_all(
         &self
     ) -> Result<Vec<Student>, Error> {
         let mut conn = self.pool.get().unwrap();
@@ -77,9 +74,9 @@ impl StudentRepository for StudentRepositorySqlImpl{
             .get_results(&mut conn)
     }
 
-    async fn get_by_id(
+     fn get_by_id(
             &self,
-            student_id: &String,
+            student_id: String,
         ) -> Result<Student, Error> {
         let mut conn = self.pool.get().unwrap();
         student::table
@@ -87,10 +84,10 @@ impl StudentRepository for StudentRepositorySqlImpl{
             .get_result(&mut conn)
     }
 
-    async fn get_by_name(
+     fn get_by_name(
         &self,
-        family_name: &String,
-        given_name: &String,
+        family_name: String,
+        given_name: String,
     ) -> Result<Vec<Student>, Error> {
         let mut conn = self.pool.get().unwrap();
         let family_name_ex = format!("{}%", family_name);
@@ -101,7 +98,7 @@ impl StudentRepository for StudentRepositorySqlImpl{
             .get_results(&mut conn)
     }
 
-    async fn delete_all(
+     fn delete_all(
         &self
     ) -> Result<usize, Error> {
         let mut conn = self.pool.get().unwrap();

--- a/src/adapters/repository/student_pair.rs
+++ b/src/adapters/repository/student_pair.rs
@@ -1,11 +1,11 @@
 use diesel::pg::PgConnection;
 use diesel::prelude::*;
-use diesel::result::Error;
 use uuid::Uuid;
 
 use crate::infrastructure::schema::*;
 use crate::infrastructure::models::*;
 use crate::infrastructure::router::Pool;
+use super::RepositoryError;
 
 /// # student_pair
 pub trait StudentPairRepository: Send + Sync {
@@ -14,33 +14,33 @@ pub trait StudentPairRepository: Send + Sync {
         student_id1: String,
         student_id2: String,
         year: i32,
-    ) -> Result<StudentPair, Error>;
+    ) -> Result<StudentPair, RepositoryError>;
 
     fn get_all(
         &self,
-    ) -> Result<Vec<StudentPair>, Error>;
+    ) -> Result<Vec<StudentPair>, RepositoryError>;
 
     fn get_by_student_id_and_year(
         &self,
         student_id: String,
         year: i32,
-    ) -> Result<StudentPair, Error>;
+    ) -> Result<StudentPair, RepositoryError>;
 
     fn get_by_main_id_and_year(
         &self,
         student_id: String,
         year: i32,
-    ) -> Result<StudentPair, Error>;
+    ) -> Result<StudentPair, RepositoryError>;
 
     fn get_by_pair_id_and_year(
         &self,
         pair_id : Uuid,
         year: i32,
-    ) -> Result<StudentPair, Error>;
+    ) -> Result<StudentPair, RepositoryError>;
 
     fn delete_all(
         &self
-    ) -> Result<usize, Error>;
+    ) -> Result<usize, RepositoryError>;
 }
 
 pub struct StudentPairRepositorySqlImpl{
@@ -59,76 +59,88 @@ impl StudentPairRepository for StudentPairRepositorySqlImpl{
         student_id1: String,
         student_id2: String,
         year: i32,
-    ) -> Result<StudentPair, Error> {
+    ) -> Result<StudentPair, RepositoryError> {
         let new_studentpair = NewStudentPair {
             student_id1: &student_id1,
             student_id2: &student_id2,
             year: &year,
         };
-        let mut conn = self.pool.get().unwrap();
-        diesel::insert_into(student_pair::table)
+        let mut conn = self.pool.get()?;
+        let result = diesel::insert_into(student_pair::table)
             .values(&new_studentpair)
-            .get_result(&mut conn)
+            .get_result::<StudentPair>(&mut conn)?;
+
+        Ok(result)
     }
 
     fn get_all(
         &self,
-    ) -> Result<Vec<StudentPair>, Error> {
-        let mut conn = self.pool.get().unwrap();
-        student_pair::table
-            .get_results(&mut conn)
+    ) -> Result<Vec<StudentPair>, RepositoryError> {
+        let mut conn = self.pool.get()?;
+        let result = student_pair::table
+            .get_results::<StudentPair>(&mut conn)?;
+
+        Ok(result)
     }
 
     fn get_by_student_id_and_year(
         &self,
         student_id: String,
         year: i32,
-    ) -> Result<StudentPair, Error> {
-        let mut conn = self.pool.get().unwrap();
-        student_pair::table
+    ) -> Result<StudentPair, RepositoryError> {
+        let mut conn = self.pool.get()?;
+        let result = student_pair::table
             .filter(
                 student_pair::student_id1
                     .eq(student_id.clone())
                     .or(student_pair::student_id2.eq(student_id))
                     .and(student_pair::year.eq(year))
             )
-            .first(&mut conn)
+            .first::<StudentPair>(&mut conn)?;
+
+        Ok(result)
     }
 
     fn get_by_main_id_and_year(
         &self,
         student_id: String,
         year: i32,
-    ) -> Result<StudentPair, Error> {
-        let mut conn = self.pool.get().unwrap();
-        student_pair::table
+    ) -> Result<StudentPair, RepositoryError> {
+        let mut conn = self.pool.get()?;
+        let result = student_pair::table
             .filter(
                 student_pair::student_id1
                     .eq(student_id)
                     .and(student_pair::year.eq(year))
             )
-            .first(&mut conn)
+            .first::<StudentPair>(&mut conn)?;
+
+        Ok(result)
     }
 
     fn get_by_pair_id_and_year(
         &self,
         pair_id: Uuid,
         year: i32,
-    ) -> Result<StudentPair, Error> {
-        let mut conn = self.pool.get().unwrap();
-        student_pair::table
+    ) -> Result<StudentPair, RepositoryError> {
+        let mut conn = self.pool.get()?;
+        let result = student_pair::table
             .filter(
                 student_pair::pair_id
                     .eq(pair_id)
                     .and(student_pair::year.eq(year))
-            ).get_result(&mut conn)
+            ).get_result::<StudentPair>(&mut conn)?;
+
+        Ok(result)
     }
 
     fn delete_all(
         &self
-    ) -> Result<usize, Error> {
-        let mut conn = self.pool.get().unwrap();
-        diesel::delete(student_pair::table)
-            .execute(&mut conn)
+    ) -> Result<usize, RepositoryError> {
+        let mut conn = self.pool.get()?;
+        let result = diesel::delete(student_pair::table)
+            .execute(&mut conn)?;
+
+        Ok(result)
     }
 }

--- a/src/adapters/repository/student_pair.rs
+++ b/src/adapters/repository/student_pair.rs
@@ -2,45 +2,43 @@ use diesel::pg::PgConnection;
 use diesel::prelude::*;
 use diesel::result::Error;
 use uuid::Uuid;
-use async_trait::async_trait;
 
 use crate::infrastructure::schema::*;
 use crate::infrastructure::models::*;
 use crate::infrastructure::router::Pool;
 
 /// # student_pair
-#[async_trait]
 pub trait StudentPairRepository: Send + Sync {
-    async fn insert(
+    fn insert(
         &self,
-        student_id1: &String,
-        student_id2: &String,
-        year: &i32,
+        student_id1: String,
+        student_id2: String,
+        year: i32,
     ) -> Result<StudentPair, Error>;
 
-    async fn get_all(
+    fn get_all(
         &self,
     ) -> Result<Vec<StudentPair>, Error>;
 
-    async fn get_by_student_id_and_year(
+    fn get_by_student_id_and_year(
         &self,
-        student_id: &String,
-        year: &i32,
+        student_id: String,
+        year: i32,
     ) -> Result<StudentPair, Error>;
 
-    async fn get_by_main_id_and_year(
+    fn get_by_main_id_and_year(
         &self,
-        student_id: &String,
-        year: &i32,
+        student_id: String,
+        year: i32,
     ) -> Result<StudentPair, Error>;
 
-    async fn get_by_pair_id_and_year(
+    fn get_by_pair_id_and_year(
         &self,
-        pair_id : &Uuid,
-        year: &i32,
+        pair_id : Uuid,
+        year: i32,
     ) -> Result<StudentPair, Error>;
 
-    async fn delete_all(
+    fn delete_all(
         &self
     ) -> Result<usize, Error>;
 }
@@ -55,18 +53,17 @@ impl StudentPairRepositorySqlImpl {
     }
 }
 
-#[async_trait]
 impl StudentPairRepository for StudentPairRepositorySqlImpl{
-    async fn insert(
+    fn insert(
         &self,
-        student_id1: &String,
-        student_id2: &String,
-        year: &i32,
+        student_id1: String,
+        student_id2: String,
+        year: i32,
     ) -> Result<StudentPair, Error> {
         let new_studentpair = NewStudentPair {
-            student_id1,
-            student_id2,
-            year,
+            student_id1: &student_id1,
+            student_id2: &student_id2,
+            year: &year,
         };
         let mut conn = self.pool.get().unwrap();
         diesel::insert_into(student_pair::table)
@@ -74,7 +71,7 @@ impl StudentPairRepository for StudentPairRepositorySqlImpl{
             .get_result(&mut conn)
     }
 
-    async fn get_all(
+    fn get_all(
         &self,
     ) -> Result<Vec<StudentPair>, Error> {
         let mut conn = self.pool.get().unwrap();
@@ -82,26 +79,26 @@ impl StudentPairRepository for StudentPairRepositorySqlImpl{
             .get_results(&mut conn)
     }
 
-    async fn get_by_student_id_and_year(
+    fn get_by_student_id_and_year(
         &self,
-        student_id: &String,
-        year: &i32,
+        student_id: String,
+        year: i32,
     ) -> Result<StudentPair, Error> {
         let mut conn = self.pool.get().unwrap();
         student_pair::table
             .filter(
                 student_pair::student_id1
-                    .eq(student_id)
+                    .eq(student_id.clone())
                     .or(student_pair::student_id2.eq(student_id))
                     .and(student_pair::year.eq(year))
             )
             .first(&mut conn)
     }
 
-    async fn get_by_main_id_and_year(
+    fn get_by_main_id_and_year(
         &self,
-        student_id: &String,
-        year: &i32,
+        student_id: String,
+        year: i32,
     ) -> Result<StudentPair, Error> {
         let mut conn = self.pool.get().unwrap();
         student_pair::table
@@ -113,10 +110,10 @@ impl StudentPairRepository for StudentPairRepositorySqlImpl{
             .first(&mut conn)
     }
 
-    async fn get_by_pair_id_and_year(
+    fn get_by_pair_id_and_year(
         &self,
-        pair_id: &Uuid,
-        year: &i32,
+        pair_id: Uuid,
+        year: i32,
     ) -> Result<StudentPair, Error> {
         let mut conn = self.pool.get().unwrap();
         student_pair::table
@@ -127,7 +124,7 @@ impl StudentPairRepository for StudentPairRepositorySqlImpl{
             ).get_result(&mut conn)
     }
 
-    async fn delete_all(
+    fn delete_all(
         &self
     ) -> Result<usize, Error> {
         let mut conn = self.pool.get().unwrap();

--- a/src/adapters/repository/time.rs
+++ b/src/adapters/repository/time.rs
@@ -2,29 +2,27 @@ use chrono::NaiveDateTime;
 use diesel::pg::PgConnection;
 use diesel::prelude::*;
 use diesel::result::Error;
-use async_trait::async_trait;
 
 use crate::infrastructure::schema::*;
 use crate::infrastructure::models::*;
 use crate::infrastructure::router::Pool;
 
 /// # time
-#[async_trait]
 pub trait TimeRepository: Send + Sync {
-    async fn insert(
+    fn insert(
         &self,
-        name: &String,
-        start_time: &NaiveDateTime,
-        end_time: &NaiveDateTime,
+        name: String,
+        start_time: NaiveDateTime,
+        end_time: NaiveDateTime,
     ) -> Result<Time, Error>;
 
-    async fn get_all(
+    fn get_all(
         &self,
     ) -> Result<Vec<Time>, Error>;
 
-    async fn get_by_name(
+    fn get_by_name(
         &self,
-        name: &String,
+        name: String,
     ) -> Result<Time, Error>;
 }
 
@@ -38,18 +36,17 @@ impl TimeRepositorySqlImpl {
     }
 }
 
-#[async_trait]
 impl TimeRepository for TimeRepositorySqlImpl {
-    async fn insert(
+    fn insert(
             &self,
-            name: &String,
-            start_time: &NaiveDateTime,
-            end_time: &NaiveDateTime,
+            name: String,
+            start_time: NaiveDateTime,
+            end_time: NaiveDateTime,
         ) -> Result<Time, Error> {
         let new_time = NewTime{
-            name: name,
-            start_time: start_time,
-            end_time: end_time,
+            name: &name,
+            start_time: &start_time,
+            end_time: &end_time,
         };
         let mut conn = self.pool.get().unwrap();
         diesel::insert_into(time::table)
@@ -60,7 +57,7 @@ impl TimeRepository for TimeRepositorySqlImpl {
             .get_result(&mut conn)
     }
 
-    async fn get_all(
+    fn get_all(
             &self,
         ) -> Result<Vec<Time>, Error> {
         let mut conn = self.pool.get().unwrap();
@@ -68,9 +65,9 @@ impl TimeRepository for TimeRepositorySqlImpl {
             .get_results(&mut conn)
     }
 
-    async fn get_by_name(
+    fn get_by_name(
             &self,
-            name: &String,
+            name: String,
         ) -> Result<Time, Error> {
         let mut conn = self.pool.get().unwrap();
         time::table

--- a/src/domain/assignment.rs
+++ b/src/domain/assignment.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
-#[derive(Deserialize, Serialize, ToSchema)]
+#[derive(Debug, Clone, Deserialize, Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct AssignmentInfo {
     #[schema(example = "4622999")]

--- a/src/domain/student_pair.rs
+++ b/src/domain/student_pair.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
-#[derive(Clone, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct PairInfo {
     #[schema(inline)]

--- a/src/infrastructure/router.rs
+++ b/src/infrastructure/router.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 use std::env;
+use std::time::Duration;
 use diesel::{PgConnection, r2d2::ConnectionManager};
 use dotenv::dotenv;
 use crate::adapters::repository::{
@@ -65,7 +66,10 @@ impl App{
 
         let database_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set.");
         let manager = ConnectionManager::<PgConnection>::new(&database_url);
-        let pool = Pool::builder().build(manager).expect("Failed to create pool");
+        let pool = Pool::builder()
+            .connection_timeout(Duration::from_secs(5))
+            .build(manager)
+            .expect("Failed to create pool");
 
         let student_repository = StudentUsecaseImpl::new(Arc::new(StudentRepositorySqlImpl::new(pool.clone())));
         let student_pair_repository = StudentPairUsecaseImpl::new(Arc::new(StudentPairRepositorySqlImpl::new(pool.clone())));

--- a/src/usecase/admin.rs
+++ b/src/usecase/admin.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 use crate::adapters::repository::admin::AdminRepository;
 use crate::infrastructure::models::Admin;
-use diesel::result::Error;
 use async_trait::async_trait;
+use rocket::{tokio::task, http::Status};
 
 pub struct AdminUsecaseImpl {
     pub admin_repository: Arc<dyn AdminRepository>,
@@ -10,7 +10,7 @@ pub struct AdminUsecaseImpl {
 
 #[async_trait]
 pub trait AdminUsecase: Sync + Send {
-    async fn get_by_name(&self, username: &String) -> Result<Admin, Error>;
+    async fn get_by_name(&self, username: &String) -> Result<Admin, Status>;
 }
 
 impl AdminUsecaseImpl {
@@ -21,7 +21,15 @@ impl AdminUsecaseImpl {
 
 #[async_trait]
 impl AdminUsecase for AdminUsecaseImpl {
-    async fn get_by_name(&self, username: &String) -> Result<Admin, Error> {
-        self.admin_repository.get_by_name(username).await
+    async fn get_by_name(&self, username: &String) -> Result<Admin, Status> {
+        let username = username.clone();
+        let repository = self.admin_repository.clone();
+
+        match task::spawn_blocking(move || {
+            repository.get_by_name(username)
+        }).await {
+            Ok(Ok(admin)) => Ok(admin),
+            _ => Err(Status::InternalServerError)
+        }
     }
 }

--- a/src/usecase/admin.rs
+++ b/src/usecase/admin.rs
@@ -1,5 +1,5 @@
 use std::sync::Arc;
-use crate::adapters::repository::admin::AdminRepository;
+use crate::adapters::repository::{RepositoryError, admin::AdminRepository};
 use crate::infrastructure::models::Admin;
 use async_trait::async_trait;
 use rocket::{tokio::task, http::Status};
@@ -28,8 +28,19 @@ impl AdminUsecase for AdminUsecaseImpl {
         match task::spawn_blocking(move || {
             repository.get_by_name(username)
         }).await {
-            Ok(Ok(admin)) => Ok(admin),
-            _ => Err(Status::InternalServerError)
+            Err(e) => {
+                eprintln!("Thread panic in spawn_blocking: {:?}", e);
+                Err(Status::InternalServerError)
+            },
+            Ok(Err(RepositoryError::ConnectionError(e))) => {
+                eprintln!("Connection Error: {:?}", e);
+                Err(Status::ServiceUnavailable)
+            },
+            Ok(Err(RepositoryError::DieselError(e))) => {
+                eprintln!("Repository Error: {:?}", e);
+                Err(Status::InternalServerError)
+            },
+            Ok(Ok(admin)) => Ok(admin)
         }
     }
 }

--- a/src/usecase/assignment_record.rs
+++ b/src/usecase/assignment_record.rs
@@ -2,9 +2,10 @@ use std::sync::Arc;
 use crate::domain::assignment::AssignmentInfo;
 use crate::adapters::repository::assignment_record::AssignmentRecordRepository;
 use crate::infrastructure::models::{AssignmentRecord, StudentPair};
-use diesel::result::Error;
 use async_trait::async_trait;
 use chrono::{Datelike, Local};
+use rocket::http::Status;
+use rocket::tokio::task;
 use uuid::Uuid;
 
 pub struct AssignmentRecordUsecaseImpl {
@@ -13,10 +14,10 @@ pub struct AssignmentRecordUsecaseImpl {
 
 #[async_trait]
 pub trait AssignmentRecordUsecase: Sync + Send {
-    async fn register(&self, student_pair: &StudentPair, assignment: &AssignmentInfo) -> Result<AssignmentRecord, Error>;
-    async fn get_all(&self) -> Result<Vec<AssignmentRecord>, Error>;
-    async fn get(&self, year: &i32, floor: Option<i8>, pair_id: &Uuid) -> Result<Vec<AssignmentRecord>, Error>;
-    async fn get_by_pair_id(&self, pair_id: &Uuid) -> Result<AssignmentRecord, Error>;
+    async fn register(&self, student_pair: &StudentPair, assignment: &AssignmentInfo) -> Result<AssignmentRecord, Status>;
+    async fn get_all(&self) -> Result<Vec<AssignmentRecord>, Status>;
+    async fn get(&self, year: &i32, floor: Option<i8>, pair_id: &Uuid) -> Result<Vec<AssignmentRecord>, Status>;
+    async fn get_by_pair_id(&self, pair_id: &Uuid) -> Result<Option<AssignmentRecord>, Status>;
 }
 
 impl AssignmentRecordUsecaseImpl {
@@ -27,25 +28,59 @@ impl AssignmentRecordUsecaseImpl {
 
 #[async_trait]
 impl AssignmentRecordUsecase for AssignmentRecordUsecaseImpl {
-    async fn register(&self, student_pair: &StudentPair, assignment: &AssignmentInfo) -> Result<AssignmentRecord, Error> {
+    async fn register(&self, student_pair: &StudentPair, assignment: &AssignmentInfo) -> Result<AssignmentRecord, Status> {
+        let pair_id = student_pair.pair_id.clone();
+        let locker_id = assignment.locker_id.clone();
         let year = Local::now().year();
-        self.assignment_record_repository.insert(&student_pair.pair_id, &assignment.locker_id, &year).await
+        let repository = self.assignment_record_repository.clone();
+
+        match task::spawn_blocking(move || {
+             repository.insert(pair_id, locker_id, year)
+        }).await {
+            Ok(Ok(assignment)) => Ok(assignment),
+            _ => Err(Status::InternalServerError)
+        }
     }
 
-    async fn get_all(&self) -> Result<Vec<AssignmentRecord>, Error> {
-        self.assignment_record_repository.get_all().await
+    async fn get_all(&self) -> Result<Vec<AssignmentRecord>, Status> {
+        let repository = self.assignment_record_repository.clone();
+
+        match task::spawn_blocking(move || {
+            repository.get_all()
+        }).await {
+            Ok(Ok(result)) => Ok(result),
+            _ => Err(Status::InternalServerError)
+        }
     }
 
-    async fn get(&self, year: &i32, floor: Option<i8>, pair_id: &Uuid) -> Result<Vec<AssignmentRecord>, Error> {
+    async fn get(&self, year: &i32, floor: Option<i8>, pair_id: &Uuid) -> Result<Vec<AssignmentRecord>, Status> {
+        let year = *year;
         let floor_val = match floor {
             None => String::from(""),
             Some(x) => format!("{}", x),
         };
-        self.assignment_record_repository.get(year, &floor_val, pair_id).await
+        let pair_id = *pair_id;
+        let repository = self.assignment_record_repository.clone();
+
+        match task::spawn_blocking(move || {
+            repository.get(year, floor_val, pair_id)
+        }).await {
+            Ok(Ok(result)) => Ok(result),
+            _ => Err(Status::InternalServerError)
+        }
     }
 
-    async fn get_by_pair_id(&self, pair_id: &Uuid) -> Result<AssignmentRecord, Error> {
+    async fn get_by_pair_id(&self, pair_id: &Uuid) -> Result<Option<AssignmentRecord>, Status> {
         let year = Local::now().year();
-        self.assignment_record_repository.get_by_pair_id(&year, pair_id).await
-    }
+        let pair_id = *pair_id;
+        let repository = self.assignment_record_repository.clone();
+
+        match task::spawn_blocking(move || {
+            repository.get_by_pair_id(year, pair_id)
+        }).await {
+            Ok(Ok(result)) => Ok(Some(result)),
+            Ok(Err(diesel::NotFound)) => Ok(None),
+            _ => Err(Status::InternalServerError)
+        }
+   }
 }

--- a/src/usecase/auth.rs
+++ b/src/usecase/auth.rs
@@ -11,7 +11,7 @@ use lettre::message::header::ContentType;
 use lettre::transport::smtp::authentication::Credentials;
 use lettre::transport::smtp::client::{Tls, TlsParameters};
 use lettre::{Message, SmtpTransport, Transport};
-use rocket::http::Status;
+use rocket::{tokio::task, http::Status};
 use async_trait::async_trait;
 
 pub struct AuthUsecaseImpl {
@@ -47,18 +47,28 @@ impl AuthUsecase for AuthUsecaseImpl {
         if is_same {
             co_token.clone_from(&main_token);
         }
-        let auth = match self.auth_repository.insert(&main_token, &co_token, phase).await {
-            Ok(auth) => {auth},
-            Err(_) => {return Err(Status::InternalServerError)}
+        let phase = phase.clone();
+        let main_user = main_user.clone();
+        let co_user = co_user.clone();
+        let auth_repository = self.auth_repository.clone();
+        let locker_auth_info_repository = self.locker_auth_info_repository.clone();
+
+        let auth = match task::spawn_blocking(move || {
+            auth_repository.insert(main_token, co_token, phase)
+        }).await {
+            Ok(Ok(auth)) => {auth},
+            _ => {return Err(Status::InternalServerError)}
         };
 
-        match self.locker_auth_info_repository.insert(&auth.auth_id,
-                                                    &main_user.student_id,
-                                                    &main_user.family_name,
-                                                    &main_user.given_name,
-                                                    &co_user.student_id,
-                                                    &co_user.family_name,
-                                                    &co_user.given_name).await {
+        match task::spawn_blocking(move || {
+            locker_auth_info_repository.insert(auth.auth_id,
+                                                main_user.student_id,
+                                                main_user.family_name,
+                                                main_user.given_name,
+                                                co_user.student_id,
+                                                co_user.family_name,
+                                                co_user.given_name)
+        }).await {
             Ok(_) => {return Ok(auth)},
             Err(_) => {return Err(Status::InternalServerError)},
         }
@@ -68,32 +78,41 @@ impl AuthUsecase for AuthUsecaseImpl {
     async fn circle_register(&self, organization: &OrganizationInfo, phase: &String, is_same: bool) -> Result<Auth, Status> {
         let main_token = generate_token();
         let mut co_token = generate_token();
-
         if is_same {
             co_token.clone_from(&main_token);
         }
-        let auth = match self.auth_repository.insert(&main_token, &co_token, phase).await {
-            Ok(auth) => {auth},
-            Err(_) => {return Err(Status::InternalServerError)}
+        let phase = phase.clone();
+        let organization = organization.clone();
+        let auth_repository = self.auth_repository.clone();
+        let circle_auth_info_repository = self.circle_auth_info_repository.clone();
+
+
+        let auth = match task::spawn_blocking(move || {
+            auth_repository.insert(main_token, co_token, phase)
+        }).await {
+            Ok(Ok(auth)) => {auth},
+            _ => {return Err(Status::InternalServerError)}
         };
 
-        match self.circle_auth_info_repository.insert(&auth.auth_id,
-                                                    &organization.main_user.student_id,
-                                                    &organization.main_user.family_name,
-                                                    &organization.main_user.given_name,
-                                                    &organization.main_user.email,
-                                                    &organization.main_user.phone_number,
-                                                    &organization.co_user.student_id,
-                                                    &organization.co_user.family_name,
-                                                    &organization.co_user.given_name,
-                                                    &organization.co_user.email,
-                                                    &organization.co_user.phone_number,
-                                                    &organization.b_doc,
-                                                    &organization.c_doc,
-                                                    &organization.d_doc,
-                                                    &organization.organization.organization_name,
-                                                    &organization.organization.organization_ruby,
-                                                    &organization.organization.organization_email).await {
+        match task::spawn_blocking(move || {
+            circle_auth_info_repository.insert(auth.auth_id,
+                                                organization.main_user.student_id,
+                                                organization.main_user.family_name,
+                                                organization.main_user.given_name,
+                                                organization.main_user.email,
+                                                organization.main_user.phone_number,
+                                                organization.co_user.student_id,
+                                                organization.co_user.family_name,
+                                                organization.co_user.given_name,
+                                                organization.co_user.email,
+                                                organization.co_user.phone_number,
+                                                organization.b_doc,
+                                                organization.c_doc,
+                                                organization.d_doc,
+                                                organization.organization.organization_name,
+                                                organization.organization.organization_ruby,
+                                                organization.organization.organization_email)
+        }).await {
             Ok(_) => {return Ok(auth)},
             Err(_) => {return Err(Status::InternalServerError)}
         }
@@ -131,7 +150,7 @@ impl AuthUsecase for AuthUsecaseImpl {
         let mailer = SmtpTransport::relay("smtp.gmail.com")
             .map_err(|_| Status::InternalServerError)?
             .port(587)
-            .tls(Tls::Required(tls_parameters)) 
+            .tls(Tls::Required(tls_parameters))
             .credentials(creds)
             .build();
 
@@ -140,43 +159,88 @@ impl AuthUsecase for AuthUsecaseImpl {
 
         Ok(())
     }
+
     async fn token_check(&self, token: String, is_main: bool) -> Result<Auth, Status> {
-        let auth = match self.auth_repository.get_by_token(&token).await {
-            Ok(auth) => auth,
-            Err(_) => return Err(Status::Unauthorized),
+        let verify_token = token.clone();
+        let repository = self.auth_repository.clone();
+
+        let auth = match task::spawn_blocking(move || {
+            repository.get_by_token(token)
+        }).await {
+            Ok(Ok(auth)) => auth,
+            _ => return Err(Status::Unauthorized),
         };
-        if (is_main && auth.main_auth_token == token) || (!is_main && auth.co_auth_token == token) {
+
+        if (is_main && auth.main_auth_token == verify_token) || (!is_main && auth.co_auth_token == verify_token) {
             Ok(auth)
         } else {
             Err(Status::Unauthorized)
         }
     }
+
     async fn get_locker_auth_info(&self, auth_id: &Uuid) -> Result<LockerAuthInfo, Status> {
-        match self.locker_auth_info_repository.get_by_id(auth_id).await {
-            Ok(info) => Ok(info),
-            Err(_) => return Err(Status::InternalServerError)
+        let auth_id = auth_id.clone();
+        let repository = self.locker_auth_info_repository.clone();
+
+        match task::spawn_blocking(move || {
+            repository.get_by_id(auth_id)
+        }).await {
+            Ok(Ok(info)) => Ok(info),
+            _ => Err(Status::InternalServerError)
         }
     }
+
     async fn get_circle_auth_info(&self, auth_id:&Uuid) -> Result<CircleAuthInfo, Status> {
-        match self.circle_auth_info_repository.get_by_id(auth_id).await {
-            Ok(info) => Ok(info),
-            Err(_) => return Err(Status::InternalServerError)
+        let auth_id = auth_id.clone();
+        let repository = self.circle_auth_info_repository.clone();
+
+        match task::spawn_blocking(move || {
+            repository.get_by_id(auth_id)
+        }).await {
+            Ok(Ok(info)) => Ok(info),
+            _ => Err(Status::InternalServerError)
         }
     }
+
     async  fn update_phase(&self, auth_id: &Uuid, phase: String) -> Result<usize, Status> {
-        match self.auth_repository.update_phase(&auth_id, &phase).await {
-            Ok(ok) => Ok(ok),
-            Err(_) => return Err(Status::InternalServerError),
+        let auth_id = auth_id.clone();
+        let repository = self.auth_repository.clone();
+
+        match task::spawn_blocking(move || {
+            repository.update_phase(auth_id, phase)
+        }).await {
+            Ok(Ok(result)) => Ok(result),
+            _ => Err(Status::InternalServerError),
         }
     }
+
     async  fn delete(&self, auth_id: &Uuid) -> Result<usize, Status> {
-        match self.locker_auth_info_repository.delete(&auth_id).await {
+        let locker_auth_id = auth_id.clone();
+        let circle_auth_id = auth_id.clone();
+        let auth_id = auth_id.clone();
+        let auth_repository = self.auth_repository.clone();
+        let locker_auth_info_repository = self.locker_auth_info_repository.clone();
+        let circle_auth_info_repository = self.circle_auth_info_repository.clone();
+
+        match task::spawn_blocking(move || {
+            locker_auth_info_repository.delete(locker_auth_id)
+        }).await {
             Ok(_) => {},
-            Err(_) => return Err(Status::InternalServerError),
+            _ => return Err(Status::InternalServerError),
         }
-        match self.auth_repository.delete(&auth_id).await {
-            Ok(ok) => Ok(ok),
-            Err(_) => return Err(Status::InternalServerError),
+
+        match task::spawn_blocking(move || {
+            circle_auth_info_repository.delete(circle_auth_id)
+        }).await {
+            Ok(_) => {},
+            _ => return Err(Status::InternalServerError),
+        }
+
+        match task::spawn_blocking(move || {
+            auth_repository.delete(auth_id)
+        }).await {
+            Ok(Ok(result)) => Ok(result),
+            _ => return Err(Status::InternalServerError),
         }
     }
 }

--- a/src/usecase/auth.rs
+++ b/src/usecase/auth.rs
@@ -186,12 +186,12 @@ impl AuthUsecase for AuthUsecaseImpl {
         let creds = Credentials::new(sender_address.to_owned(), appkey.to_owned());
 
         // TLSパラメータを生成
-        let tls_parameters = TlsParameters::builder("tus-yuurikai.jp".to_string())
+        let tls_parameters = TlsParameters::builder("smtp.gmail.com".to_string())
         .build()
         .map_err(|_| Status::InternalServerError)?;
 
         // Gmailにsmtp接続する
-        let mailer = SmtpTransport::relay("tus-yuurikai.jp")
+        let mailer = SmtpTransport::relay("smtp.gmail.com")
             .map_err(|_| Status::InternalServerError)?
             .port(587)
             .tls(Tls::Required(tls_parameters))

--- a/src/usecase/locker.rs
+++ b/src/usecase/locker.rs
@@ -1,9 +1,8 @@
 use std::sync::Arc;
 use crate::adapters::repository::locker::LockerRepository;
 use crate::infrastructure::models::Locker;
-use diesel::result::Error;
 use async_trait::async_trait;
-use rocket::http::Status;
+use rocket::{tokio::task, http::Status};
 
 pub struct LockerUsecaseImpl {
     pub locker_repository: Arc<dyn LockerRepository>,
@@ -11,11 +10,11 @@ pub struct LockerUsecaseImpl {
 
 #[async_trait]
 pub trait LockerUsecase: Sync + Send {
-    async fn get_all(&self) -> Result<Vec<Locker>, Error>;
-    async fn get_by_id(&self, locker_id: &String) -> Result<Locker, Error>;
-    async fn get_by_floor(&self, floor: &Option<i8>) -> Result<Vec<Locker>, Error>;
-    async fn update_status(&self, locker_id: &String, status: &String) -> Result<usize, Error>;
-    async fn reset_status(&self) -> Result<Status, Error>;
+    async fn get_all(&self) -> Result<Vec<Locker>, Status>;
+    async fn get_by_id(&self, locker_id: &String) -> Result<Locker, Status>;
+    async fn get_by_floor(&self, floor: &Option<i8>) -> Result<Vec<Locker>, Status>;
+    async fn update_status(&self, locker_id: &String, status: &String) -> Result<usize, Status>;
+    async fn reset_status(&self) -> Result<usize, Status>;
 }
 
 impl LockerUsecaseImpl {
@@ -26,34 +25,66 @@ impl LockerUsecaseImpl {
 
 #[async_trait]
 impl LockerUsecase for LockerUsecaseImpl {
-    async fn get_all(&self) -> Result<Vec<Locker>, Error> {
-        self.locker_repository.get_all().await
-    }
-    
-    async fn get_by_id(&self, locker_id: &String) -> Result<Locker, Error> {
-        self.locker_repository.get_by_id(locker_id).await
+    async fn get_all(&self) -> Result<Vec<Locker>, Status> {
+        let repository = self.locker_repository.clone();
+
+        match task::spawn_blocking(move || {
+            repository.get_all()
+        }).await {
+            Ok(Ok(lockers)) => Ok(lockers),
+            _ => Err(Status::InternalServerError)
+        }
     }
 
-    async fn get_by_floor(&self, floor: &Option<i8>) -> Result<Vec<Locker>, Error> {
+    async fn get_by_id(&self, locker_id: &String) -> Result<Locker, Status> {
+        let locker_id = locker_id.clone();
+        let repository = self.locker_repository.clone();
+
+        match task::spawn_blocking(move || {
+            repository.get_by_id(locker_id)
+        }).await {
+            Ok(Ok(locker)) => Ok(locker),
+            _ => Err(Status::InternalServerError)
+        }
+    }
+
+    async fn get_by_floor(&self, floor: &Option<i8>) -> Result<Vec<Locker>, Status> {
         let floor_val = match floor {
             None => String::from(""),
             Some(x) => format!("{}", x),
         };
-        self.locker_repository.get_by_floor(&floor_val).await
+        let repository = self.locker_repository.clone();
+
+        match task::spawn_blocking(move || {
+            repository.get_by_floor(floor_val)
+        }).await {
+            Ok(Ok(lockers)) => Ok(lockers),
+            _ => Err(Status::InternalServerError)
+        }
     }
 
-    async  fn update_status(&self, locker_id: &String, status: &String) -> Result<usize, Error> {
-        self.locker_repository.update_status_by_id(locker_id, status).await
+    async  fn update_status(&self, locker_id: &String, status: &String) -> Result<usize, Status> {
+        let locker_id = locker_id.clone();
+        let status = status.clone();
+        let repository = self.locker_repository.clone();
+
+        match task::spawn_blocking(move || {
+            repository.update_status_by_id(locker_id, status)
+        }).await {
+            Ok(Ok(result)) => Ok(result),
+            _ => Err(Status::InternalServerError)
+        }
     }
 
-    async fn reset_status(&self) -> Result<Status, Error> {
+    async fn reset_status(&self) -> Result<usize, Status> {
+        let repository = self.locker_repository.clone();
 
         // statusを更新
-        match self.locker_repository.update_status(&String::from(""), &String::from("occupied"), &String::from("vacant")).await {
-            Ok(_) => {},
-            Err(err) => {return Err(err)},
-        };
-
-        Ok(Status::Ok)
+        match task::spawn_blocking(move || {
+            repository.update_status(String::from(""), String::from("occupied"), String::from("vacant"))
+        }).await {
+            Ok(Ok(result)) => Ok(result),
+            _ => Err(Status::InternalServerError),
+        }
     }
 }

--- a/src/usecase/locker.rs
+++ b/src/usecase/locker.rs
@@ -1,5 +1,5 @@
 use std::sync::Arc;
-use crate::adapters::repository::locker::LockerRepository;
+use crate::adapters::repository::{RepositoryError, locker::LockerRepository};
 use crate::infrastructure::models::Locker;
 use async_trait::async_trait;
 use rocket::{tokio::task, http::Status};
@@ -31,8 +31,19 @@ impl LockerUsecase for LockerUsecaseImpl {
         match task::spawn_blocking(move || {
             repository.get_all()
         }).await {
+            Err(e) => {
+                eprintln!("Thread panic in spawn_blocking: {:?}", e);
+                Err(Status::InternalServerError)
+            },
+            Ok(Err(RepositoryError::ConnectionError(e))) => {
+                eprintln!("Connection Error: {:?}", e);
+                Err(Status::ServiceUnavailable)
+            },
+            Ok(Err(RepositoryError::DieselError(e))) => {
+                eprintln!("Repository Error: {:?}", e);
+                Err(Status::InternalServerError)
+            },
             Ok(Ok(lockers)) => Ok(lockers),
-            _ => Err(Status::InternalServerError)
         }
     }
 
@@ -43,8 +54,19 @@ impl LockerUsecase for LockerUsecaseImpl {
         match task::spawn_blocking(move || {
             repository.get_by_id(locker_id)
         }).await {
+            Err(e) => {
+                eprintln!("Thread panic in spawn_blocking: {:?}", e);
+                return Err(Status::InternalServerError)
+            },
+            Ok(Err(RepositoryError::ConnectionError(e))) => {
+                eprintln!("Connection Error: {:?}", e);
+                return Err(Status::ServiceUnavailable)
+            },
+            Ok(Err(RepositoryError::DieselError(e))) => {
+                eprintln!("Repository Error: {:?}", e);
+                return Err(Status::InternalServerError)
+            },
             Ok(Ok(locker)) => Ok(locker),
-            _ => Err(Status::InternalServerError)
         }
     }
 
@@ -58,8 +80,19 @@ impl LockerUsecase for LockerUsecaseImpl {
         match task::spawn_blocking(move || {
             repository.get_by_floor(floor_val)
         }).await {
+            Err(e) => {
+                eprintln!("Thread panic in spawn_blocking: {:?}", e);
+                return Err(Status::InternalServerError)
+            },
+            Ok(Err(RepositoryError::ConnectionError(e))) => {
+                eprintln!("Connection Error: {:?}", e);
+                return Err(Status::ServiceUnavailable)
+            },
+            Ok(Err(RepositoryError::DieselError(e))) => {
+                eprintln!("Repository Error: {:?}", e);
+                return Err(Status::InternalServerError)
+            },
             Ok(Ok(lockers)) => Ok(lockers),
-            _ => Err(Status::InternalServerError)
         }
     }
 
@@ -71,8 +104,19 @@ impl LockerUsecase for LockerUsecaseImpl {
         match task::spawn_blocking(move || {
             repository.update_status_by_id(locker_id, status)
         }).await {
+            Err(e) => {
+                eprintln!("Thread panic in spawn_blocking: {:?}", e);
+                return Err(Status::InternalServerError)
+            },
+            Ok(Err(RepositoryError::ConnectionError(e))) => {
+                eprintln!("Connection Error: {:?}", e);
+                return Err(Status::ServiceUnavailable)
+            },
+            Ok(Err(RepositoryError::DieselError(e))) => {
+                eprintln!("Repository Error: {:?}", e);
+                return Err(Status::InternalServerError)
+            },
             Ok(Ok(result)) => Ok(result),
-            _ => Err(Status::InternalServerError)
         }
     }
 
@@ -83,8 +127,19 @@ impl LockerUsecase for LockerUsecaseImpl {
         match task::spawn_blocking(move || {
             repository.update_status(String::from(""), String::from("occupied"), String::from("vacant"))
         }).await {
+            Err(e) => {
+                eprintln!("Thread panic in spawn_blocking: {:?}", e);
+                Err(Status::InternalServerError)
+            },
+            Ok(Err(RepositoryError::ConnectionError(e))) => {
+                eprintln!("Connection Error: {:?}", e);
+                Err(Status::ServiceUnavailable)
+            },
+            Ok(Err(RepositoryError::DieselError(e))) => {
+                eprintln!("Repository Error: {:?}", e);
+                Err(Status::InternalServerError)
+            },
             Ok(Ok(result)) => Ok(result),
-            _ => Err(Status::InternalServerError),
         }
     }
 }

--- a/src/usecase/organization.rs
+++ b/src/usecase/organization.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 use crate::domain::circle::Organization;
-use crate::adapters::repository::organization::OrganizationRepository;
+use crate::adapters::repository::{RepositoryError, organization::OrganizationRepository};
 use crate::infrastructure::models;
 use async_trait::async_trait;
 use rocket::{tokio::task, http::Status};
@@ -32,8 +32,19 @@ impl OrganizationUsecase for OrganizationUsecaseImpl {
         match task::spawn_blocking(move || {
             repository.insert(organization.organization_name, organization.organization_ruby, organization.organization_email)
         }).await {
+            Err(e) => {
+                eprintln!("Thread panic in spawn_blocking: {:?}", e);
+                Err(Status::InternalServerError)
+            },
+            Ok(Err(RepositoryError::ConnectionError(e))) => {
+                eprintln!("Connection Error: {:?}", e);
+                Err(Status::ServiceUnavailable)
+            },
+            Ok(Err(RepositoryError::DieselError(e))) => {
+                eprintln!("Repository Error: {:?}", e);
+                Err(Status::InternalServerError)
+            },
             Ok(Ok(organization)) => Ok(organization),
-            _ => Err(Status::InternalServerError)
         }
     }
 
@@ -43,8 +54,19 @@ impl OrganizationUsecase for OrganizationUsecaseImpl {
         match task::spawn_blocking(move || {
             repository.get_all()
         }).await {
+            Err(e) => {
+                eprintln!("Thread panic in spawn_blocking: {:?}", e);
+                Err(Status::InternalServerError)
+            },
+            Ok(Err(RepositoryError::ConnectionError(e))) => {
+                eprintln!("Connection Error: {:?}", e);
+                Err(Status::ServiceUnavailable)
+            },
+            Ok(Err(RepositoryError::DieselError(e))) => {
+                eprintln!("Repository Error: {:?}", e);
+                Err(Status::InternalServerError)
+            },
             Ok(Ok(organizations)) => Ok(organizations),
-            _ => Err(Status::InternalServerError)
         }
     }
 
@@ -57,8 +79,19 @@ impl OrganizationUsecase for OrganizationUsecaseImpl {
         match task::spawn_blocking(move || {
             repository.update_email_by_id(organization_id, organization_email)
         }).await {
+            Err(e) => {
+                eprintln!("Thread panic in spawn_blocking: {:?}", e);
+                Err(Status::InternalServerError)
+            },
+            Ok(Err(RepositoryError::ConnectionError(e))) => {
+                eprintln!("Connection Error: {:?}", e);
+                Err(Status::ServiceUnavailable)
+            },
+            Ok(Err(RepositoryError::DieselError(e))) => {
+                eprintln!("Repository Error: {:?}", e);
+                Err(Status::InternalServerError)
+            },
             Ok(Ok(organization)) => Ok(organization),
-            _ => Err(Status::InternalServerError)
         }
     }
 
@@ -70,8 +103,19 @@ impl OrganizationUsecase for OrganizationUsecaseImpl {
         match task::spawn_blocking(move || {
             repository.get_by_id(organization_id)
         }).await {
+            Err(e) => {
+                eprintln!("Thread panic in spawn_blocking: {:?}", e);
+                Err(Status::InternalServerError)
+            },
+            Ok(Err(RepositoryError::ConnectionError(e))) => {
+                eprintln!("Connection Error: {:?}", e);
+                Err(Status::ServiceUnavailable)
+            },
+            Ok(Err(RepositoryError::DieselError(e))) => {
+                eprintln!("Repository Error: {:?}", e);
+                Err(Status::InternalServerError)
+            },
             Ok(Ok(organization)) => Ok(organization),
-            _ => Err(Status::InternalServerError)
         }
     }
 }

--- a/src/usecase/organization.rs
+++ b/src/usecase/organization.rs
@@ -2,8 +2,8 @@ use std::sync::Arc;
 use crate::domain::circle::Organization;
 use crate::adapters::repository::organization::OrganizationRepository;
 use crate::infrastructure::models;
-use diesel::result::Error;
 use async_trait::async_trait;
+use rocket::{tokio::task, http::Status};
 
 pub struct OrganizationUsecaseImpl {
     pub organization_repository: Arc<dyn OrganizationRepository>,
@@ -11,10 +11,10 @@ pub struct OrganizationUsecaseImpl {
 
 #[async_trait]
 pub trait OrganizationUsecase: Sync + Send {
-    async fn register(&self, organization: &Organization) -> Result<models::Organization, Error>;
-    async fn get_all(&self) -> Result<Vec<models::Organization>, Error>;
-    async fn update_email(&self, organization_id: &i32, organization_email: &String) -> Result<models::Organization, Error>;
-    async fn get_by_id(&self, organization_id: &i32) -> Result<models::Organization, Error>;
+    async fn register(&self, organization: &Organization) -> Result<models::Organization, Status>;
+    async fn get_all(&self) -> Result<Vec<models::Organization>, Status>;
+    async fn update_email(&self, organization_id: &i32, organization_email: &String) -> Result<models::Organization, Status>;
+    async fn get_by_id(&self, organization_id: &i32) -> Result<models::Organization, Status>;
 }
 
 impl OrganizationUsecaseImpl {
@@ -25,22 +25,53 @@ impl OrganizationUsecaseImpl {
 
 #[async_trait]
 impl OrganizationUsecase for OrganizationUsecaseImpl {
-    async fn register(&self, organization: &Organization) -> Result<models::Organization, Error> {
+    async fn register(&self, organization: &Organization) -> Result<models::Organization, Status> {
+        let organization = organization.clone();
+        let repository = self.organization_repository.clone();
         // 団体情報の登録
-        self.organization_repository.insert(&organization.organization_name, &organization.organization_ruby, &organization.organization_email).await
+        match task::spawn_blocking(move || {
+            repository.insert(organization.organization_name, organization.organization_ruby, organization.organization_email)
+        }).await {
+            Ok(Ok(organization)) => Ok(organization),
+            _ => Err(Status::InternalServerError)
+        }
     }
 
-    async fn get_all(&self) -> Result<Vec<models::Organization>, Error> {
-        self.organization_repository.get_all().await
+    async fn get_all(&self) -> Result<Vec<models::Organization>, Status> {
+        let repository = self.organization_repository.clone();
+
+        match task::spawn_blocking(move || {
+            repository.get_all()
+        }).await {
+            Ok(Ok(organizations)) => Ok(organizations),
+            _ => Err(Status::InternalServerError)
+        }
     }
 
-    async fn update_email(&self, organization_id: &i32, organization_email: &String) -> Result<models::Organization, Error> {
+    async fn update_email(&self, organization_id: &i32, organization_email: &String) -> Result<models::Organization, Status> {
+        let organization_id = *organization_id;
+        let organization_email = organization_email.clone();
+        let repository = self.organization_repository.clone();
+
         // 団体メールアドレスの更新
-        self.organization_repository.update_email_by_id(organization_id, organization_email).await
+        match task::spawn_blocking(move || {
+            repository.update_email_by_id(organization_id, organization_email)
+        }).await {
+            Ok(Ok(organization)) => Ok(organization),
+            _ => Err(Status::InternalServerError)
+        }
     }
 
-    async fn get_by_id(&self, organization_id: &i32) -> Result<models::Organization, Error> {
+    async fn get_by_id(&self, organization_id: &i32) -> Result<models::Organization, Status> {
+        let organization_id = *organization_id;
+        let repository = self.organization_repository.clone();
+
         // 団体情報の取得
-        self.organization_repository.get_by_id(organization_id).await
+        match task::spawn_blocking(move || {
+            repository.get_by_id(organization_id)
+        }).await {
+            Ok(Ok(organization)) => Ok(organization),
+            _ => Err(Status::InternalServerError)
+        }
     }
 }

--- a/src/usecase/registration.rs
+++ b/src/usecase/registration.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 use crate::domain::circle::OrganizationInfo;
-use crate::adapters::repository::registration::RegistrationRepository;
+use crate::adapters::repository::{RepositoryError, registration::RegistrationRepository};
 use crate::infrastructure::models::Registration;
 use async_trait::async_trait;
 use rocket::{tokio::task, http::Status};
@@ -52,8 +52,19 @@ impl RegistrationUsecase for RegistrationUsecaseImpl {
                             organization.d_doc
                             )
         }).await {
+            Err(e) => {
+                eprintln!("Thread panic in spawn_blocking: {:?}", e);
+                Err(Status::InternalServerError)
+            },
+            Ok(Err(RepositoryError::ConnectionError(e))) => {
+                eprintln!("Connection Error: {:?}", e);
+                Err(Status::ServiceUnavailable)
+            },
+            Ok(Err(RepositoryError::DieselError(e))) => {
+                eprintln!("Repository Error: {:?}", e);
+                Err(Status::InternalServerError)
+            },
             Ok(Ok(registration)) => Ok(registration),
-            _ => Err(Status::InternalServerError)
         }
     }
 
@@ -67,8 +78,19 @@ impl RegistrationUsecase for RegistrationUsecaseImpl {
         match task::spawn_blocking(move || {
             repository.update_student_by_id(organization_id, main_student_id, co_student_id)
         }).await {
+            Err(e) => {
+                eprintln!("Thread panic in spawn_blocking: {:?}", e);
+                Err(Status::InternalServerError)
+            },
+            Ok(Err(RepositoryError::ConnectionError(e))) => {
+                eprintln!("Connection Error: {:?}", e);
+                Err(Status::ServiceUnavailable)
+            },
+            Ok(Err(RepositoryError::DieselError(e))) => {
+                eprintln!("Repository Error: {:?}", e);
+                Err(Status::InternalServerError)
+            },
             Ok(Ok(registration)) => Ok(registration),
-            _ => Err(Status::InternalServerError)
         }
     }
 
@@ -84,8 +106,19 @@ impl RegistrationUsecase for RegistrationUsecaseImpl {
         match task::spawn_blocking(move || {
             repository.update_status_by_id(organization_id, status_acceptance, status_authentication, status_form_confirmation, status_registration_complete)
         }).await {
+            Err(e) => {
+                eprintln!("Thread panic in spawn_blocking: {:?}", e);
+                Err(Status::InternalServerError)
+            },
+            Ok(Err(RepositoryError::ConnectionError(e))) => {
+                eprintln!("Connection Error: {:?}", e);
+                Err(Status::ServiceUnavailable)
+            },
+            Ok(Err(RepositoryError::DieselError(e))) => {
+                eprintln!("Repository Error: {:?}", e);
+                Err(Status::InternalServerError)
+            },
             Ok(Ok(registration)) => Ok(registration),
-            _ => Err(Status::InternalServerError)
         }
     }
 
@@ -96,8 +129,19 @@ impl RegistrationUsecase for RegistrationUsecaseImpl {
         match task::spawn_blocking(move || {
             repository.get_all()
         }).await {
+            Err(e) => {
+                eprintln!("Thread panic in spawn_blocking: {:?}", e);
+                Err(Status::InternalServerError)
+            },
+            Ok(Err(RepositoryError::ConnectionError(e))) => {
+                eprintln!("Connection Error: {:?}", e);
+                Err(Status::ServiceUnavailable)
+            },
+            Ok(Err(RepositoryError::DieselError(e))) => {
+                eprintln!("Repository Error: {:?}", e);
+                Err(Status::InternalServerError)
+            },
             Ok(Ok(registrations)) => Ok(registrations),
-            _ => Err(Status::InternalServerError)
         }
     }
 }

--- a/src/usecase/registration.rs
+++ b/src/usecase/registration.rs
@@ -2,8 +2,8 @@ use std::sync::Arc;
 use crate::domain::circle::OrganizationInfo;
 use crate::adapters::repository::registration::RegistrationRepository;
 use crate::infrastructure::models::Registration;
-use diesel::result::Error;
 use async_trait::async_trait;
+use rocket::{tokio::task, http::Status};
 use chrono::{Datelike, Local};
 
 
@@ -13,10 +13,10 @@ pub struct RegistrationUsecaseImpl {
 
 #[async_trait]
 pub trait RegistrationUsecase: Sync + Send {
-    async fn register(&self, organization: &OrganizationInfo, organization_id: &i32) -> Result<Registration, Error>;
-    async fn update_student(&self, organization_id: &i32, main_student_id: &String, co_student_id: &String) -> Result<Registration, Error>;
-    async fn update_status(&self, organization_id: &i32, status_acceptance: &String, status_authentication: &String, status_form_confirmation: &String, status_registration_complete: &String) -> Result<Registration, Error>;
-    async fn get_all(&self) -> Result<Vec<Registration>, Error>;
+    async fn register(&self, organization: &OrganizationInfo, organization_id: &i32) -> Result<Registration, Status>;
+    async fn update_student(&self, organization_id: &i32, main_student_id: &String, co_student_id: &String) -> Result<Registration, Status>;
+    async fn update_status(&self, organization_id: &i32, status_acceptance: &String, status_authentication: &String, status_form_confirmation: &String, status_registration_complete: &String) -> Result<Registration, Status>;
+    async fn get_all(&self) -> Result<Vec<Registration>, Status>;
 }
 
 impl RegistrationUsecaseImpl {
@@ -27,39 +27,77 @@ impl RegistrationUsecaseImpl {
 
 #[async_trait]
 impl RegistrationUsecase for RegistrationUsecaseImpl {
-    async fn register(&self, organization: &OrganizationInfo, organization_id: &i32) -> Result<Registration, Error> {
+    async fn register(&self, organization: &OrganizationInfo, organization_id: &i32) -> Result<Registration, Status> {
         // 団体情報の登録
         let year = Local::now().year();
         let init_status_acpt = String::from("pending");
         let init_status_auth = String::from("not_authenticated");
         let init_status_form = String::from("not_confirmed");
         let init_status_rgst = String::from("incomplete");
-        self.registration_repository.insert(organization_id,
-                                            &year,
-                                            &organization.main_user.student_id,
-                                            &organization.co_user.student_id,
-                                            &init_status_acpt,
-                                            &init_status_auth,
-                                            &init_status_form,
-                                            &init_status_rgst,
-                                            &organization.b_doc,
-                                            &organization.c_doc,
-                                            &organization.d_doc
-                                            ).await
+        let organization = organization.clone();
+        let organization_id = *organization_id;
+        let repository = self.registration_repository.clone();
+
+        match task::spawn_blocking(move || {
+            repository.insert(organization_id,
+                            year,
+                            organization.main_user.student_id,
+                            organization.co_user.student_id,
+                            init_status_acpt,
+                            init_status_auth,
+                            init_status_form,
+                            init_status_rgst,
+                            organization.b_doc,
+                            organization.c_doc,
+                            organization.d_doc
+                            )
+        }).await {
+            Ok(Ok(registration)) => Ok(registration),
+            _ => Err(Status::InternalServerError)
+        }
     }
 
-    async fn update_student(&self, organization_id: &i32, main_student_id: &String, co_student_id: &String) -> Result<Registration, Error> {
+    async fn update_student(&self, organization_id: &i32, main_student_id: &String, co_student_id: &String) -> Result<Registration, Status> {
+        let organization_id = *organization_id;
+        let main_student_id = main_student_id.clone();
+        let co_student_id = co_student_id.clone();
+        let repository = self.registration_repository.clone();
+
         // 団体代表者と団体副代表者の更新
-        self.registration_repository.update_student_by_id(organization_id, main_student_id, co_student_id).await
+        match task::spawn_blocking(move || {
+            repository.update_student_by_id(organization_id, main_student_id, co_student_id)
+        }).await {
+            Ok(Ok(registration)) => Ok(registration),
+            _ => Err(Status::InternalServerError)
+        }
     }
 
-    async fn update_status(&self, organization_id: &i32, status_acceptance: &String, status_authentication: &String, status_form_confirmation: &String, status_registration_complete: &String) -> Result<Registration, Error> {
+    async fn update_status(&self, organization_id: &i32, status_acceptance: &String, status_authentication: &String, status_form_confirmation: &String, status_registration_complete: &String) -> Result<Registration, Status> {
+        let organization_id = *organization_id;
+        let status_acceptance = status_acceptance.clone();
+        let status_authentication = status_authentication.clone();
+        let status_form_confirmation = status_form_confirmation.clone();
+        let status_registration_complete = status_registration_complete.clone();
+        let repository = self.registration_repository.clone();
+
         // 団体のステータス更新
-        self.registration_repository.update_status_by_id(organization_id, status_acceptance, status_authentication, status_form_confirmation, status_registration_complete).await
+        match task::spawn_blocking(move || {
+            repository.update_status_by_id(organization_id, status_acceptance, status_authentication, status_form_confirmation, status_registration_complete)
+        }).await {
+            Ok(Ok(registration)) => Ok(registration),
+            _ => Err(Status::InternalServerError)
+        }
     }
 
-    async fn get_all(&self) -> Result<Vec<Registration>, Error> {
+    async fn get_all(&self) -> Result<Vec<Registration>, Status> {
+        let repository = self.registration_repository.clone();
+
         // 団体情報を更新
-        self.registration_repository.get_all().await
+        match task::spawn_blocking(move || {
+            repository.get_all()
+        }).await {
+            Ok(Ok(registrations)) => Ok(registrations),
+            _ => Err(Status::InternalServerError)
+        }
     }
 }

--- a/src/usecase/representatives.rs
+++ b/src/usecase/representatives.rs
@@ -1,5 +1,5 @@
 use std::sync::Arc;
-use crate::adapters::repository::representatives::RepresentativesRepository;
+use crate::adapters::repository::{RepositoryError, representatives::RepresentativesRepository};
 use crate::domain::student::RepresentativeInfo;
 use crate::infrastructure::models::Representatives;
 use rocket::{tokio::task, http::Status};
@@ -31,8 +31,19 @@ impl RepresentativesUsecase for RepresentativesUsecaseImpl {
         match task::spawn_blocking(move || {
             repository.insert(student.student_id, student.family_name, student.given_name, student.email, student.phone_number)
         }).await {
+            Err(e) => {
+                eprintln!("Thread panic in spawn_blocking: {:?}", e);
+                Err(Status::InternalServerError)
+            },
+            Ok(Err(RepositoryError::ConnectionError(e))) => {
+                eprintln!("Connection Error: {:?}", e);
+                Err(Status::ServiceUnavailable)
+            },
+            Ok(Err(RepositoryError::DieselError(e))) => {
+                eprintln!("Repository Error: {:?}", e);
+                Err(Status::InternalServerError)
+            },
             Ok(Ok(representatives)) => Ok(representatives),
-            _ => Err(Status::InternalServerError)
         }
     }
 
@@ -42,8 +53,19 @@ impl RepresentativesUsecase for RepresentativesUsecaseImpl {
         match task::spawn_blocking(move || {
             repository.get_all()
         }).await {
+            Err(e) => {
+                eprintln!("Thread panic in spawn_blocking: {:?}", e);
+                Err(Status::InternalServerError)
+            },
+            Ok(Err(RepositoryError::ConnectionError(e))) => {
+                eprintln!("Connection Error: {:?}", e);
+                Err(Status::ServiceUnavailable)
+            },
+            Ok(Err(RepositoryError::DieselError(e))) => {
+                eprintln!("Repository Error: {:?}", e);
+                Err(Status::InternalServerError)
+            },
             Ok(Ok(representativeses)) => Ok(representativeses),
-            _ => Err(Status::InternalServerError)
         }
     }
 
@@ -54,8 +76,19 @@ impl RepresentativesUsecase for RepresentativesUsecaseImpl {
         match task::spawn_blocking(move || {
             repository.get_by_id(student_id)
         }).await {
+            Err(e) => {
+                eprintln!("Thread panic in spawn_blocking: {:?}", e);
+                Err(Status::InternalServerError)
+            },
+            Ok(Err(RepositoryError::ConnectionError(e))) => {
+                eprintln!("Connection Error: {:?}", e);
+                Err(Status::ServiceUnavailable)
+            },
+            Ok(Err(RepositoryError::DieselError(e))) => {
+                eprintln!("Repository Error: {:?}", e);
+                Err(Status::InternalServerError)
+            },
             Ok(Ok(representatives)) => Ok(representatives),
-            _ => Err(Status::InternalServerError)
         }
     }
 }

--- a/src/usecase/student.rs
+++ b/src/usecase/student.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 use crate::domain::student::UserInfo;
-use crate::adapters::repository::student::StudentRepository;
+use crate::adapters::repository::{RepositoryError, student::StudentRepository};
 use crate::infrastructure::models::Student;
 use rocket::{tokio::task, http::Status};
 use async_trait::async_trait;
@@ -32,8 +32,19 @@ impl StudentUsecase for StudentUsecaseImpl {
         match task::spawn_blocking(move || {
             repository.insert(student.student_id, student.family_name, student.given_name)
         }).await {
+            Err(e) => {
+                eprintln!("Thread panic in spawn_blocking: {:?}", e);
+                Err(Status::InternalServerError)
+            },
+            Ok(Err(RepositoryError::ConnectionError(e))) => {
+                eprintln!("Connection Error: {:?}", e);
+                Err(Status::ServiceUnavailable)
+            },
+            Ok(Err(RepositoryError::DieselError(e))) => {
+                eprintln!("Repository Error: {:?}", e);
+                Err(Status::InternalServerError)
+            },
             Ok(Ok(student)) => Ok(student),
-            _ => Err(Status::InternalServerError)
         }
     }
 
@@ -43,8 +54,19 @@ impl StudentUsecase for StudentUsecaseImpl {
         match task::spawn_blocking(move || {
             repository.get_all()
         }).await {
+            Err(e) => {
+                eprintln!("Thread panic in spawn_blocking: {:?}", e);
+                Err(Status::InternalServerError)
+            },
+            Ok(Err(RepositoryError::ConnectionError(e))) => {
+                eprintln!("Connection Error: {:?}", e);
+                Err(Status::ServiceUnavailable)
+            },
+            Ok(Err(RepositoryError::DieselError(e))) => {
+                eprintln!("Repository Error: {:?}", e);
+                Err(Status::InternalServerError)
+            },
             Ok(Ok(students)) => Ok(students),
-            _ => Err(Status::InternalServerError)
         }
     }
 
@@ -55,8 +77,19 @@ impl StudentUsecase for StudentUsecaseImpl {
         match task::spawn_blocking(move || {
             repository.get_by_id(student_id)
         }).await {
+            Err(e) => {
+                eprintln!("Thread panic in spawn_blocking: {:?}", e);
+                Err(Status::InternalServerError)
+            },
+            Ok(Err(RepositoryError::ConnectionError(e))) => {
+                eprintln!("Connection Error: {:?}", e);
+                Err(Status::ServiceUnavailable)
+            },
+            Ok(Err(RepositoryError::DieselError(e))) => {
+                eprintln!("Repository Error: {:?}", e);
+                Err(Status::InternalServerError)
+            },
             Ok(Ok(student)) => Ok(student),
-            _ => Err(Status::InternalServerError)
         }
     }
 
@@ -68,8 +101,19 @@ impl StudentUsecase for StudentUsecaseImpl {
         match task::spawn_blocking(move || {
             repository.get_by_name(family_name, given_name)
         }).await {
+            Err(e) => {
+                eprintln!("Thread panic in spawn_blocking: {:?}", e);
+                Err(Status::InternalServerError)
+            },
+            Ok(Err(RepositoryError::ConnectionError(e))) => {
+                eprintln!("Connection Error: {:?}", e);
+                Err(Status::ServiceUnavailable)
+            },
+            Ok(Err(RepositoryError::DieselError(e))) => {
+                eprintln!("Repository Error: {:?}", e);
+                Err(Status::InternalServerError)
+            },
             Ok(Ok(students)) => Ok(students),
-            _ => Err(Status::InternalServerError)
         }
     }
 }

--- a/src/usecase/student.rs
+++ b/src/usecase/student.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use crate::domain::student::UserInfo;
 use crate::adapters::repository::student::StudentRepository;
 use crate::infrastructure::models::Student;
-use diesel::result::Error;
+use rocket::{tokio::task, http::Status};
 use async_trait::async_trait;
 
 pub struct StudentUsecaseImpl {
@@ -11,10 +11,10 @@ pub struct StudentUsecaseImpl {
 
 #[async_trait]
 pub trait StudentUsecase: Sync + Send {
-    async fn register(&self, student: &UserInfo) -> Result<Student, Error>;
-    async fn get_all(&self) -> Result<Vec<Student>, Error>;
-    async fn get_by_id(&self, student_id: &String) -> Result<Student, Error>;
-    async fn get_by_name(&self, family_name: &String, given_name: &String) -> Result<Vec<Student>, Error>;
+    async fn register(&self, student: &UserInfo) -> Result<Student, Status>;
+    async fn get_all(&self) -> Result<Vec<Student>, Status>;
+    async fn get_by_id(&self, student_id: &String) -> Result<Student, Status>;
+    async fn get_by_name(&self, family_name: &String, given_name: &String) -> Result<Vec<Student>, Status>;
 }
 
 impl StudentUsecaseImpl {
@@ -25,19 +25,51 @@ impl StudentUsecaseImpl {
 
 #[async_trait]
 impl StudentUsecase for StudentUsecaseImpl {
-    async fn register(&self, student: &UserInfo) -> Result<Student, Error> {
-        self.student_repository.insert(&student.student_id, &student.family_name, &student.given_name).await
+    async fn register(&self, student: &UserInfo) -> Result<Student, Status> {
+        let student = student.clone();
+        let repository = self.student_repository.clone();
+
+        match task::spawn_blocking(move || {
+            repository.insert(student.student_id, student.family_name, student.given_name)
+        }).await {
+            Ok(Ok(student)) => Ok(student),
+            _ => Err(Status::InternalServerError)
+        }
     }
 
-    async fn get_all(&self) -> Result<Vec<Student>, Error> {
-        self.student_repository.get_all().await
+    async fn get_all(&self) -> Result<Vec<Student>, Status> {
+        let repository = self.student_repository.clone();
+
+        match task::spawn_blocking(move || {
+            repository.get_all()
+        }).await {
+            Ok(Ok(students)) => Ok(students),
+            _ => Err(Status::InternalServerError)
+        }
     }
 
-    async  fn get_by_id(&self, student_id: &String) -> Result<Student, Error> {
-        self.student_repository.get_by_id(student_id).await
+    async  fn get_by_id(&self, student_id: &String) -> Result<Student, Status> {
+        let student_id = student_id.clone();
+        let repository = self.student_repository.clone();
+
+        match task::spawn_blocking(move || {
+            repository.get_by_id(student_id)
+        }).await {
+            Ok(Ok(student)) => Ok(student),
+            _ => Err(Status::InternalServerError)
+        }
     }
 
-    async fn get_by_name(&self, family_name: &String, given_name: &String) -> Result<Vec<Student>, Error> {
-        self.student_repository.get_by_name(family_name, given_name).await
+    async fn get_by_name(&self, family_name: &String, given_name: &String) -> Result<Vec<Student>, Status> {
+        let family_name = family_name.clone();
+        let given_name = given_name.clone();
+        let repository = self.student_repository.clone();
+
+        match task::spawn_blocking(move || {
+            repository.get_by_name(family_name, given_name)
+        }).await {
+            Ok(Ok(students)) => Ok(students),
+            _ => Err(Status::InternalServerError)
+        }
     }
 }

--- a/src/usecase/student_pair.rs
+++ b/src/usecase/student_pair.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use crate::domain::student_pair::PairInfo;
 use crate::adapters::repository::student_pair::StudentPairRepository;
 use crate::infrastructure::models::StudentPair;
-use diesel::result::Error;
+use rocket::{tokio::task, http::Status};
 use async_trait::async_trait;
 use chrono::{Datelike, Local};
 
@@ -12,11 +12,11 @@ pub struct StudentPairUsecaseImpl {
 
 #[async_trait]
 pub trait StudentPairUsecase: Sync + Send {
-    async fn register(&self, student_pair: &PairInfo) -> Result<StudentPair, Error>;
-    async fn get_all(&self) -> Result<Vec<StudentPair>, Error>;
-    async fn get_by_id(&self, student_id: &String) -> Result<StudentPair, Error>;
-    async fn get_by_main_id(&self, student_id: &String) -> Result<StudentPair, Error>;
-    async fn get_by_pair_id(&self, pair_id: &uuid::Uuid) -> Result<StudentPair, Error>;
+    async fn register(&self, student_pair: &PairInfo) -> Result<StudentPair, Status>;
+    async fn get_all(&self) -> Result<Vec<StudentPair>, Status>;
+    async fn get_by_id(&self, student_id: &String) -> Result<StudentPair, Status>;
+    async fn get_by_main_id(&self, student_id: &String) -> Result<StudentPair, Status>;
+    async fn get_by_pair_id(&self, pair_id: &uuid::Uuid) -> Result<StudentPair, Status>;
 }
 
 impl StudentPairUsecaseImpl {
@@ -27,27 +27,66 @@ impl StudentPairUsecaseImpl {
 
 #[async_trait]
 impl StudentPairUsecase for StudentPairUsecaseImpl {
-    async fn register(&self, student_pair: &PairInfo) -> Result<StudentPair, Error> {
+    async fn register(&self, student_pair: &PairInfo) -> Result<StudentPair, Status> {
+        let student_pair = student_pair.clone();
         let year = Local::now().year();
-        self.student_pair_repository.insert(&student_pair.main_user.student_id, &student_pair.co_user.student_id, &year).await
+        let repository = self.student_pair_repository.clone();
+
+        match task::spawn_blocking(move || {
+            repository.insert(student_pair.main_user.student_id, student_pair.co_user.student_id, year)
+        }).await {
+            Ok(Ok(student_pair)) => Ok(student_pair),
+            _ => Err(Status::InternalServerError)
+        }
     }
 
-    async fn get_all(&self) -> Result<Vec<StudentPair>, Error> {
-        self.student_pair_repository.get_all().await
+    async fn get_all(&self) -> Result<Vec<StudentPair>, Status> {
+        let repository = self.student_pair_repository.clone();
+
+        match task::spawn_blocking(move || {
+            repository.get_all()
+        }).await {
+            Ok(Ok(student_pairs)) => Ok(student_pairs),
+            _ => Err(Status::InternalServerError)
+        }
     }
 
-    async fn get_by_id(&self, student_id: &String) -> Result<StudentPair, Error> {
+    async fn get_by_id(&self, student_id: &String) -> Result<StudentPair, Status> {
+        let student_id = student_id.clone();
         let year = Local::now().year();
-        self.student_pair_repository.get_by_student_id_and_year(student_id, &year).await
+        let repository = self.student_pair_repository.clone();
+
+        match task::spawn_blocking(move || {
+            repository.get_by_student_id_and_year(student_id, year)
+        }).await {
+            Ok(Ok(student_pair)) => Ok(student_pair),
+            _ => Err(Status::InternalServerError)
+        }
     }
 
-    async fn get_by_main_id(&self, student_id: &String) -> Result<StudentPair, Error> {
+    async fn get_by_main_id(&self, student_id: &String) -> Result<StudentPair, Status> {
+        let student_id = student_id.clone();
         let year = Local::now().year();
-        self.student_pair_repository.get_by_main_id_and_year(student_id, &year).await
+        let repository = self.student_pair_repository.clone();
+
+        match task::spawn_blocking(move || {
+            repository.get_by_main_id_and_year(student_id, year)
+        }).await {
+            Ok(Ok(student_id)) => Ok(student_id),
+            _ => Err(Status::InternalServerError)
+        }
     }
-    
-    async fn get_by_pair_id(&self, pair_id: &uuid::Uuid) -> Result<StudentPair, Error> {
+
+    async fn get_by_pair_id(&self, pair_id: &uuid::Uuid) -> Result<StudentPair, Status> {
+        let pair_id = pair_id.clone();
         let year = Local::now().year();
-        self.student_pair_repository.get_by_pair_id_and_year(pair_id, &year).await
+        let repository = self.student_pair_repository.clone();
+
+        match task::spawn_blocking(move || {
+            repository.get_by_pair_id_and_year(pair_id, year)
+        }).await {
+            Ok(Ok(student_pair)) => Ok(student_pair),
+            _ => Err(Status::InternalServerError)
+        }
     }
 }

--- a/src/usecase/student_pair.rs
+++ b/src/usecase/student_pair.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 use crate::domain::student_pair::PairInfo;
-use crate::adapters::repository::student_pair::StudentPairRepository;
+use crate::adapters::repository::{RepositoryError, student_pair::StudentPairRepository};
 use crate::infrastructure::models::StudentPair;
 use rocket::{tokio::task, http::Status};
 use async_trait::async_trait;
@@ -35,8 +35,19 @@ impl StudentPairUsecase for StudentPairUsecaseImpl {
         match task::spawn_blocking(move || {
             repository.insert(student_pair.main_user.student_id, student_pair.co_user.student_id, year)
         }).await {
+            Err(e) => {
+                eprintln!("Thread panic in spawn_blocking: {:?}", e);
+                Err(Status::InternalServerError)
+            },
+            Ok(Err(RepositoryError::ConnectionError(e))) => {
+                eprintln!("Connection Error: {:?}", e);
+                Err(Status::ServiceUnavailable)
+            },
+            Ok(Err(RepositoryError::DieselError(e))) => {
+                eprintln!("Repository Error: {:?}", e);
+                Err(Status::InternalServerError)
+            },
             Ok(Ok(student_pair)) => Ok(student_pair),
-            _ => Err(Status::InternalServerError)
         }
     }
 
@@ -46,8 +57,19 @@ impl StudentPairUsecase for StudentPairUsecaseImpl {
         match task::spawn_blocking(move || {
             repository.get_all()
         }).await {
+            Err(e) => {
+                eprintln!("Thread panic in spawn_blocking: {:?}", e);
+                Err(Status::InternalServerError)
+            },
+            Ok(Err(RepositoryError::ConnectionError(e))) => {
+                eprintln!("Connection Error: {:?}", e);
+                Err(Status::ServiceUnavailable)
+            },
+            Ok(Err(RepositoryError::DieselError(e))) => {
+                eprintln!("Repository Error: {:?}", e);
+                Err(Status::InternalServerError)
+            },
             Ok(Ok(student_pairs)) => Ok(student_pairs),
-            _ => Err(Status::InternalServerError)
         }
     }
 
@@ -59,8 +81,19 @@ impl StudentPairUsecase for StudentPairUsecaseImpl {
         match task::spawn_blocking(move || {
             repository.get_by_student_id_and_year(student_id, year)
         }).await {
+            Err(e) => {
+                eprintln!("Thread panic in spawn_blocking: {:?}", e);
+                Err(Status::InternalServerError)
+            },
+            Ok(Err(RepositoryError::ConnectionError(e))) => {
+                eprintln!("Connection Error: {:?}", e);
+                Err(Status::ServiceUnavailable)
+            },
+            Ok(Err(RepositoryError::DieselError(e))) => {
+                eprintln!("Repository Error: {:?}", e);
+                Err(Status::InternalServerError)
+            },
             Ok(Ok(student_pair)) => Ok(student_pair),
-            _ => Err(Status::InternalServerError)
         }
     }
 
@@ -72,8 +105,19 @@ impl StudentPairUsecase for StudentPairUsecaseImpl {
         match task::spawn_blocking(move || {
             repository.get_by_main_id_and_year(student_id, year)
         }).await {
+            Err(e) => {
+                eprintln!("Thread panic in spawn_blocking: {:?}", e);
+                Err(Status::InternalServerError)
+            },
+            Ok(Err(RepositoryError::ConnectionError(e))) => {
+                eprintln!("Connection Error: {:?}", e);
+                Err(Status::ServiceUnavailable)
+            },
+            Ok(Err(RepositoryError::DieselError(e))) => {
+                eprintln!("Repository Error: {:?}", e);
+                Err(Status::InternalServerError)
+            },
             Ok(Ok(student_id)) => Ok(student_id),
-            _ => Err(Status::InternalServerError)
         }
     }
 
@@ -85,8 +129,19 @@ impl StudentPairUsecase for StudentPairUsecaseImpl {
         match task::spawn_blocking(move || {
             repository.get_by_pair_id_and_year(pair_id, year)
         }).await {
+            Err(e) => {
+                eprintln!("Thread panic in spawn_blocking: {:?}", e);
+                Err(Status::InternalServerError)
+            },
+            Ok(Err(RepositoryError::ConnectionError(e))) => {
+                eprintln!("Connection Error: {:?}", e);
+                Err(Status::ServiceUnavailable)
+            },
+            Ok(Err(RepositoryError::DieselError(e))) => {
+                eprintln!("Repository Error: {:?}", e);
+                Err(Status::InternalServerError)
+            },
             Ok(Ok(student_pair)) => Ok(student_pair),
-            _ => Err(Status::InternalServerError)
         }
     }
 }

--- a/src/usecase/time.rs
+++ b/src/usecase/time.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
-use crate::adapters::repository::time::TimeRepository;
+use crate::adapters::repository::{self, time::TimeRepository};
 use crate::infrastructure::models::Time;
 use chrono::NaiveDateTime;
-use diesel::result::Error;
+use rocket::{tokio::task, http::Status};
 use async_trait::async_trait;
 
 pub struct TimeUsecaseImpl {
@@ -11,9 +11,9 @@ pub struct TimeUsecaseImpl {
 
 #[async_trait]
 pub trait TimeUsecase: Sync + Send {
-    async fn register(&self, name: &String, start_time: &NaiveDateTime, end_time: &NaiveDateTime) -> Result<Time, Error>;
-    async fn get_all(&self) -> Result<Vec<Time>, Error>;
-    async fn get_by_name(&self, name: &String) -> Result<Time, Error>;
+    async fn register(&self, name: &String, start_time: &NaiveDateTime, end_time: &NaiveDateTime) -> Result<Time, Status>;
+    async fn get_all(&self) -> Result<Vec<Time>, Status>;
+    async fn get_by_name(&self, name: &String) -> Result<Time, Status>;
 }
 
 impl TimeUsecaseImpl {
@@ -24,15 +24,40 @@ impl TimeUsecaseImpl {
 
 #[async_trait]
 impl TimeUsecase for TimeUsecaseImpl {
-    async fn register(&self, name: &String, start_time: &NaiveDateTime, end_time: &NaiveDateTime) -> Result<Time, Error> {
-        self.time_repository.insert(name, start_time, end_time).await
+    async fn register(&self, name: &String, start_time: &NaiveDateTime, end_time: &NaiveDateTime) -> Result<Time, Status> {
+        let name = name.clone();
+        let start_time = *start_time;
+        let end_time = *end_time;
+        let repository = self.time_repository.clone();
+
+        match task::spawn_blocking(move || {
+            repository.insert(name, start_time, end_time)
+        }).await {
+            Ok(Ok(time)) => Ok(time),
+            _ => Err(Status::InternalServerError)
+        }
     }
 
-    async fn get_all(&self) -> Result<Vec<Time>, Error> {
-        self.time_repository.get_all().await
+    async fn get_all(&self) -> Result<Vec<Time>, Status> {
+        let repository = self.time_repository.clone();
+
+        match task::spawn_blocking(move || {
+            repository.get_all()
+        }).await {
+            Ok(Ok(times)) => Ok(times),
+            _ => Err(Status::InternalServerError)
+        }
     }
 
-    async fn get_by_name(&self, name: &String) -> Result<Time, Error> {
-        self.time_repository.get_by_name(name).await
+    async fn get_by_name(&self, name: &String) -> Result<Time, Status> {
+        let name = name.clone();
+        let repository = self.time_repository.clone();
+
+        match task::spawn_blocking(move || {
+            repository.get_by_name(name)
+        }).await {
+            Ok(Ok(time)) => Ok(time),
+            _ => Err(Status::InternalServerError)
+        }
     }
 }

--- a/src/usecase/time.rs
+++ b/src/usecase/time.rs
@@ -1,5 +1,5 @@
 use std::sync::Arc;
-use crate::adapters::repository::{self, time::TimeRepository};
+use crate::adapters::repository::{RepositoryError, time::TimeRepository};
 use crate::infrastructure::models::Time;
 use chrono::NaiveDateTime;
 use rocket::{tokio::task, http::Status};
@@ -33,8 +33,19 @@ impl TimeUsecase for TimeUsecaseImpl {
         match task::spawn_blocking(move || {
             repository.insert(name, start_time, end_time)
         }).await {
+            Err(e) => {
+                eprintln!("Thread panic in spawn_blocking: {:?}", e);
+                Err(Status::InternalServerError)
+            },
+            Ok(Err(RepositoryError::ConnectionError(e))) => {
+                eprintln!("Connection Error: {:?}", e);
+                Err(Status::ServiceUnavailable)
+            },
+            Ok(Err(RepositoryError::DieselError(e))) => {
+                eprintln!("Repository Error: {:?}", e);
+                Err(Status::InternalServerError)
+            },
             Ok(Ok(time)) => Ok(time),
-            _ => Err(Status::InternalServerError)
         }
     }
 
@@ -44,8 +55,19 @@ impl TimeUsecase for TimeUsecaseImpl {
         match task::spawn_blocking(move || {
             repository.get_all()
         }).await {
+            Err(e) => {
+                eprintln!("Thread panic in spawn_blocking: {:?}", e);
+                Err(Status::InternalServerError)
+            },
+            Ok(Err(RepositoryError::ConnectionError(e))) => {
+                eprintln!("Connection Error: {:?}", e);
+                Err(Status::ServiceUnavailable)
+            },
+            Ok(Err(RepositoryError::DieselError(e))) => {
+                eprintln!("Repository Error: {:?}", e);
+                Err(Status::InternalServerError)
+            },
             Ok(Ok(times)) => Ok(times),
-            _ => Err(Status::InternalServerError)
         }
     }
 
@@ -56,8 +78,19 @@ impl TimeUsecase for TimeUsecaseImpl {
         match task::spawn_blocking(move || {
             repository.get_by_name(name)
         }).await {
+            Err(e) => {
+                eprintln!("Thread panic in spawn_blocking: {:?}", e);
+                Err(Status::InternalServerError)
+            },
+            Ok(Err(RepositoryError::ConnectionError(e))) => {
+                eprintln!("Connection Error: {:?}", e);
+                Err(Status::ServiceUnavailable)
+            },
+            Ok(Err(RepositoryError::DieselError(e))) => {
+                eprintln!("Repository Error: {:?}", e);
+                Err(Status::InternalServerError)
+            },
             Ok(Ok(time)) => Ok(time),
-            _ => Err(Status::InternalServerError)
         }
     }
 }

--- a/tests/usersearch.rs
+++ b/tests/usersearch.rs
@@ -6,7 +6,7 @@ mod utils;
 use std::env;
 use utils::{router::rocket, setup::setup_db};
 use rocket::local::asynchronous::Client;
-use rocket::http::{Status, Cookie};
+use rocket::{tokio::task, http::{Status, Cookie}};
 use dotenv::dotenv;
 use tus_yuurikai_system::adapters::httpmodels::{UserSearchResponse, UserSearchResult};
 use tus_yuurikai_system::domain::{assignment::AssignmentInfo, student_pair::PairInfo, student::UserInfo};
@@ -73,9 +73,14 @@ async fn normal() {
     let password = String::from("0000");
 
     let password_hash = utils::password_hash::compute_password_hash(password.clone()).unwrap();
-    match app.admin.admin_repository.insert(&username, &password_hash).await {
-        Ok(_) => {},
-        Err(err) => {panic!{"{}", err}},
+    let user_name = username.clone();
+    let admin_repository = app.admin.admin_repository.clone();
+    match task::spawn_blocking(move || {
+        admin_repository.insert(user_name, password_hash)
+    }).await {
+        Ok(Ok(_)) => {},
+        Ok(Err(err)) => panic!("{}", err),
+        Err(err) => panic!("{}", err),
     }
 
     let key = env::var("TOKEN_KEY").expect("token key must be set");
@@ -103,9 +108,13 @@ async fn normal() {
         }]
     };
 
-    match app.admin.admin_repository.delete_by_name(&username).await {
-        Ok(_) => {},
-        Err(err) => {panic!{"{}",err}}
+    let admin_repository = app.admin.admin_repository.clone();
+    match task::spawn_blocking(move || {
+        admin_repository.delete_by_name(username)
+    }).await {
+        Ok(Ok(_)) => {},
+        Ok(Err(err)) => panic!("{}", err),
+        Err(err) => panic!("{}",err)
     }
 
     // Assert
@@ -173,9 +182,14 @@ async fn given_name_is_not_requested() {
     let password = String::from("0000");
 
     let password_hash = utils::password_hash::compute_password_hash(password.clone()).unwrap();
-    match app.admin.admin_repository.insert(&username, &password_hash).await {
-        Ok(_) => {},
-        Err(err) => {panic!{"{}", err}},
+    let user_name = username.clone();
+    let admin_repository = app.admin.admin_repository.clone();
+    match task::spawn_blocking(move || {
+        admin_repository.insert(user_name, password_hash)
+    }).await {
+        Ok(Ok(_)) => {},
+        Ok(Err(err)) => panic!("{}", err),
+        Err(err) => panic!("{}", err),
     }
 
     let key = env::var("TOKEN_KEY").expect("token key must be set");
@@ -204,9 +218,13 @@ async fn given_name_is_not_requested() {
         }]
     };
 
-    match app.admin.admin_repository.delete_by_name(&username).await {
-        Ok(_) => {},
-        Err(err) => {panic!{"{}",err}}
+    let admin_repository = app.admin.admin_repository.clone();
+    match task::spawn_blocking(move || {
+        admin_repository.delete_by_name(username)
+    }).await {
+        Ok(Ok(_)) => {},
+        Ok(Err(err)) => panic!("{}", err),
+        Err(err) => panic!("{}",err)
     }
 
     // Assert
@@ -274,9 +292,14 @@ async fn family_name_is_not_requested() {
     let password = String::from("0000");
 
     let password_hash = utils::password_hash::compute_password_hash(password.clone()).unwrap();
-    match app.admin.admin_repository.insert(&username, &password_hash).await {
-        Ok(_) => {},
-        Err(err) => {panic!{"{}", err}},
+    let user_name = username.clone();
+    let admin_repository = app.admin.admin_repository.clone();
+    match task::spawn_blocking(move || {
+        admin_repository.insert(user_name, password_hash)
+    }).await {
+        Ok(Ok(_)) => {},
+        Ok(Err(err)) => panic!("{}", err),
+        Err(err) => panic!("{}", err),
     }
 
     let key = env::var("TOKEN_KEY").expect("token key must be set");
@@ -304,9 +327,13 @@ async fn family_name_is_not_requested() {
         }]
     };
 
-    match app.admin.admin_repository.delete_by_name(&username).await {
-        Ok(_) => {},
-        Err(err) => {panic!{"{}",err}}
+    let admin_repository = app.admin.admin_repository.clone();
+    match task::spawn_blocking(move || {
+        admin_repository.delete_by_name(username)
+    }).await {
+        Ok(Ok(_)) => {},
+        Ok(Err(err)) => panic!("{}", err),
+        Err(err) => panic!("{}",err)
     }
 
     // Assert
@@ -374,10 +401,16 @@ async fn name_is_not_requested() {
     let password = String::from("0000");
 
     let password_hash = utils::password_hash::compute_password_hash(password.clone()).unwrap();
-    match app.admin.admin_repository.insert(&username, &password_hash).await {
-        Ok(_) => {},
-        Err(err) => {panic!{"{}", err}},
+    let user_name = username.clone();
+    let admin_repository = app.admin.admin_repository.clone();
+    match task::spawn_blocking(move || {
+        admin_repository.insert(user_name, password_hash)
+    }).await {
+        Ok(Ok(_)) => {},
+        Ok(Err(err)) => panic!("{}", err),
+        Err(err) => panic!("{}", err),
     }
+
 
     let key = env::var("TOKEN_KEY").expect("token key must be set");
     let token = encode_jwt(&username, Duration::hours(1), &key);
@@ -404,9 +437,13 @@ async fn name_is_not_requested() {
         }]
     };
 
-    match app.admin.admin_repository.delete_by_name(&username).await {
-        Ok(_) => {},
-        Err(err) => {panic!{"{}",err}}
+    let admin_repository = app.admin.admin_repository.clone();
+    match task::spawn_blocking(move || {
+        admin_repository.delete_by_name(username)
+    }).await {
+        Ok(Ok(_)) => {},
+        Ok(Err(err)) => panic!("{}", err),
+        Err(err) => panic!("{}",err)
     }
 
     // Assert

--- a/tests/utils/router.rs
+++ b/tests/utils/router.rs
@@ -10,7 +10,7 @@ use utoipa::OpenApi;
 pub fn rocket() -> Rocket<Build> {
     let app_option = AppOption::new();
     let app = App::new(app_option);
-    let rocket = rocket::build()
+    rocket::build()
         .manage(app)
         .mount(
             "/api",
@@ -50,7 +50,5 @@ pub fn rocket() -> Rocket<Build> {
         .mount(
             "/",
             SwaggerUi::new("/swagger-ui/<_..>").url("/api-docs/openapi.json", ApiDoc::openapi()),
-        );
-
-    rocket
+        )
 }

--- a/tests/utils/setup.rs
+++ b/tests/utils/setup.rs
@@ -1,31 +1,66 @@
 use tus_yuurikai_system::infrastructure::router::App;
+use rocket::tokio::task;
 
 pub async fn setup_db(app: &App) {
-    match app.assignment_record.assignment_record_repository.delete_all().await {
-        Ok(_) => {},
+    let assignment_record_repository = app.assignment_record.assignment_record_repository.clone();
+    match task::spawn_blocking(move || {
+        assignment_record_repository.delete_all()
+    }).await {
+        Ok(Ok(_)) => {},
+        Ok(Err(err)) => panic!("{}", err),
         Err(err) => panic!("{}", err),
     }
-    match app.student_pair.student_pair_repository.delete_all().await {
-        Ok(_) => {},
+
+    let student_pair_repository = app.student_pair.student_pair_repository.clone();
+    match task::spawn_blocking(move || {
+        student_pair_repository.delete_all()
+    }).await {
+        Ok(Ok(_)) => {},
+        Ok(Err(err)) => panic!("{}", err),
         Err(err) => panic!("{}", err),
     }
-    match app.student.student_repository.delete_all().await {
-        Ok(_) => {},
+
+    let student_repository = app.student.student_repository.clone();
+    match task::spawn_blocking(move || {
+        student_repository.delete_all()
+    }).await {
+        Ok(Ok(_)) => {},
+        Ok(Err(err)) => panic!("{}", err),
         Err(err) => panic!("{}", err),
     }
-    match app.auth.locker_auth_info_repository.delete_all().await {
-        Ok(_) => {},
+
+    let locker_auth_info_repository = app.auth.locker_auth_info_repository.clone();
+    match task::spawn_blocking(move || {
+        locker_auth_info_repository.delete_all()
+    }).await {
+        Ok(Ok(_)) => {},
+        Ok(Err(err)) => panic!("{}", err),
         Err(err) => panic!("{}", err),
     }
-    match app.auth.circle_auth_info_repository.delete_all().await {
-        Ok(_) => {},
+
+    let circle_auth_info_repository = app.auth.circle_auth_info_repository.clone();
+    match task::spawn_blocking(move || {
+        circle_auth_info_repository.delete_all()
+    }).await {
+        Ok(Ok(_)) => {},
+        Ok(Err(err)) => panic!("{}", err),
         Err(err) => panic!("{}", err),
     }
-    match app.auth.auth_repository.delete_all().await {
-        Ok(_) => {},
+
+    let auth_repository = app.auth.auth_repository.clone();
+    match task::spawn_blocking(move || {
+        auth_repository.delete_all()
+    }).await {
+        Ok(Ok(_)) => {},
+        Ok(Err(err)) => panic!("{}", err),
         Err(err) => panic!("{}", err),
     }
-    if app.locker.locker_repository.update_all_status(&String::from("vacant")).await.is_err() {
-        panic!("failed to update locker status");
+
+    let locker_repository = app.locker.locker_repository.clone();
+    match task::spawn_blocking(move || {
+        locker_repository.update_all_status(String::from("vacant"))
+    }).await {
+        Ok(Ok(_)) => {},
+        _ => panic!("failed to update locker status"),
     }
 }


### PR DESCRIPTION
# 概要
- dieselを利用してデータベースを操作する同期処理周りを、tokioのspawn_blocking関数を用いて切り離しました。
- repository層のトレイトを非同期トレイトでなくしました（非同期トレイトである必要がなくなったため）
- repository層において、コネクションプールの取得に失敗した場合にエラーを返すように修正しました。
- usecase層において、データベースからのエラーによって詳細にエラーハンドリングするよう調整しました。

# テスト状態
- 目視で正常に動くことを確認

# 要望
- ローカルでの確認、コードレビュー
- 変更点がデータベース周りすべてに及ぶため、団体登録、ロッカー登録の手順を順に追って確認をお願いします。