### PR TITLE
ロッカーフォーム提出数を制限

### DIFF
--- a/frontend/src/routes/locker/ConfirmPage.tsx
+++ b/frontend/src/routes/locker/ConfirmPage.tsx
@@ -75,8 +75,14 @@ const ConfirmPage: React.FC = () => {
             await axios.post(`${constants.backendApiEndpoint}/api/locker/token-gen`, formattedData);
             message.success('フォームが正常に送信されました');
             navigate('/locker/form/complete');
-        } catch (error) {
-            message.error('送信に失敗しました');
+        } catch (error: any) {
+            console.log(error.response);
+            console.log(error.response.status);
+            if (error.response && error.response.status == "429") {
+                message.warning('本日の登録分は終了しました。明日以降に再度お試しください。');
+            } else {
+                message.error('ロッカーの登録に失敗しました');
+            }
         } finally {
             setLoading(false);
         }


### PR DESCRIPTION
This pull request introduces a rate limiting feature to the locker registration system to prevent abuse. The main changes include adding rate limiting logic to the backend and updating the frontend to handle the new rate limiting responses.

Backend changes:

* Added a `MailLimit` struct to manage the rate limiting, including methods to check and increment the count, and reset it daily. (`src/infrastructure/router.rs`)
* Integrated the `MailLimit` struct into the `App` struct and initialized it using a `Mutex`. (`src/infrastructure/router.rs`) [[1]](diffhunk://#diff-572021360c0d9e6cc3f769380ed948fd92f5ce609d249c29b0cffbea991db60fR113-R114) [[2]](diffhunk://#diff-572021360c0d9e6cc3f769380ed948fd92f5ce609d249c29b0cffbea991db60fR135)
* Added logic to check the rate limit before sending an email in the `token_generator` function. If the limit is exceeded, a `TooManyRequests` status is returned. (`src/adapters/controller/locker.rs`)

Frontend changes:

* Updated the `ConfirmPage` component to handle the new rate limiting response. If a 429 status code is received, a warning message is displayed to the user. (`frontend/src/routes/locker/ConfirmPage.tsx`)