### PR TITLE
同じ学生の登録防止

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -118,10 +118,10 @@ async fn main() -> Result<(), rocket::Error> {
             ]
         )
         .mount("/", FileServer::from(relative!("frontend/build")))
-        .mount(
-            "/",
-            SwaggerUi::new("/swagger-ui/<_..>").url("/api-docs/openapi.json", ApiDoc::openapi()),
-        )
+        // .mount(
+        //     "/",
+        //     SwaggerUi::new("/swagger-ui/<_..>").url("/api-docs/openapi.json", ApiDoc::openapi()),
+        // )
         .mount("/", routes![catch_all])
         .ignite().await?
         .launch().await?;


### PR DESCRIPTION
This pull request introduces several updates to the `locker.rs` controller, the `student_pair.rs` use case, and the main application file. The changes focus on improving error handling, modifying the behavior of the `get_by_id` method to return an `Option`, and temporarily disabling Swagger UI in the main application. Below is a summary of the most important changes:

### Error Handling and Behavior Updates:
* Updated the `get_by_id` method in `StudentPairUsecase` to return `Result<Option<StudentPair>, Status>` instead of `Result<StudentPair, Status>`. This allows the method to explicitly handle cases where no matching record is found. [[1]](diffhunk://#diff-4a35df654a8d1446820be21717593552bc98233f9dfa402e2bb75012744d6a16L17-R17) [[2]](diffhunk://#diff-4a35df654a8d1446820be21717593552bc98233f9dfa402e2bb75012744d6a16L76-R76) [[3]](diffhunk://#diff-4a35df654a8d1446820be21717593552bc98233f9dfa402e2bb75012744d6a16R92-R99)
* Refactored `co_auth` and `user_search` functions in `locker.rs` to handle `None` cases explicitly when calling `get_by_id`, improving error handling and ensuring better control flow. [[1]](diffhunk://#diff-2da66aa8801a73f043cbf069fc125ae7df6b4e71f9b3510febb97f2b6aa84bf8R211-R223) [[2]](diffhunk://#diff-2da66aa8801a73f043cbf069fc125ae7df6b4e71f9b3510febb97f2b6aa84bf8L567-L571)

### Temporary Feature Disabling:
* Commented out the Swagger UI mount in `main.rs` to temporarily disable the Swagger documentation endpoint. This might be for maintenance or to reduce complexity during development.

### Minor Code Cleanup:
* Fixed an unnecessary escape character in a debug `println!` statement in the `locker_register` function. This change improves code readability without affecting functionality.